### PR TITLE
fix: move mcp sdk to dev dependency

### DIFF
--- a/package.json
+++ b/package.json
@@ -10,11 +10,7 @@
         "./package.json": "./package.json"
     },
     "type": "module",
-    "files": [
-        "dist",
-        "README.md",
-        "LICENSE"
-    ],
+    "files": ["dist", "README.md", "LICENSE"],
     "scripts": {
         "start": "bun run --watch ./scripts/start-server.ts",
         "start:test": "bun run --watch ./scripts/test-server.ts",
@@ -29,7 +25,6 @@
     "dependencies": {
         "@1password/connect": "^1.4.2",
         "@linear/sdk": "^55.0.0",
-        "@modelcontextprotocol/sdk": "^1.17.2",
         "@notionhq/client": "^4.0.1",
         "@orama/orama": "^3.1.11",
         "node-html-parser": "^7.0.1",
@@ -42,6 +37,7 @@
         "@types/bun": "^1.2.4",
         "@types/node": "^22.13.5",
         "@typescript/native-preview": "^7.0.0-dev.20250623.1",
+        "@modelcontextprotocol/sdk": "^1.17.2",
         "hono": "^4.9.0",
         "husky": "^9.1.7",
         "lint-staged": "^15.2.0",
@@ -69,8 +65,6 @@
     "bugs": "https://github.com/StackOneHQ/mcp-connectors/issues",
     "homepage": "https://github.com/StackOneHQ/mcp-connectors#readme",
     "lint-staged": {
-        "*": [
-            "biome check --fix --no-errors-on-unmatched"
-        ]
+        "*": ["biome check --fix --no-errors-on-unmatched"]
     }
 }


### PR DESCRIPTION

    
<!-- This is an auto-generated description by cubic. -->

## Summary by cubic
Moved @modelcontextprotocol/sdk from dependencies to devDependencies to reduce production bundle size.

<!-- End of auto-generated description by cubic. -->

