### PR TITLE
feat: point to correct mcp-config types

### DIFF
--- a/biome.json
+++ b/biome.json
@@ -41,6 +41,6 @@
     },
     "files": {
         "ignoreUnknown": false,
-        "ignore": ["node_modules", "dist"]
+        "ignore": ["node_modules", "dist", "bun.lock"]
     }
 }

--- a/packages/mcp-config-types/package.json
+++ b/packages/mcp-config-types/package.json
@@ -10,11 +10,7 @@
         "./package.json": "./package.json"
     },
     "type": "module",
-    "files": [
-        "dist",
-        "README.md",
-        "LICENSE"
-    ],
+    "files": ["dist", "README.md", "LICENSE"],
     "scripts": {
         "build": "bun -b tsdown",
         "prepublishOnly": "bun run build",

--- a/packages/mcp-connectors/package.json
+++ b/packages/mcp-connectors/package.json
@@ -10,11 +10,7 @@
         "./package.json": "./package.json"
     },
     "type": "module",
-    "files": [
-        "dist",
-        "README.md",
-        "LICENSE"
-    ],
+    "files": ["dist", "README.md", "LICENSE"],
     "scripts": {
         "build": "bun -b tsdown",
         "prepublishOnly": "bun run build",

--- a/packages/mcp-connectors/package.json
+++ b/packages/mcp-connectors/package.json
@@ -29,7 +29,7 @@
         "node-html-parser": "^7.0.1",
         "openai": "^5.12.1",
         "zod": "^3.25",
-        "@stackone/mcp-config-types": "workspace:*"
+        "@stackone/mcp-config-types": "^0.0.5"
     },
     "repository": {
         "type": "git",


### PR DESCRIPTION

    
<!-- This is an auto-generated description by cubic. -->

## Summary by cubic
Updated mcp-config-types dependency to use the correct published version and added bun.lock to the ignored files list for Biome.

<!-- End of auto-generated description by cubic. -->

