### PR TITLE
fix: logos to use disco

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -33,3 +33,5 @@ bun-debug.log*
 # Misc
 .turbo/
 *.log
+
+.npmrc

--- a/packages/mcp-config-types/package.json
+++ b/packages/mcp-config-types/package.json
@@ -10,11 +10,7 @@
         "./package.json": "./package.json"
     },
     "type": "module",
-    "files": [
-        "dist",
-        "README.md",
-        "LICENSE"
-    ],
+    "files": ["dist", "README.md", "LICENSE"],
     "scripts": {
         "build": "bun -b tsdown",
         "prepublishOnly": "bun run build",

--- a/packages/mcp-connectors/package.json
+++ b/packages/mcp-connectors/package.json
@@ -10,11 +10,7 @@
         "./package.json": "./package.json"
     },
     "type": "module",
-    "files": [
-        "dist",
-        "README.md",
-        "LICENSE"
-    ],
+    "files": ["dist", "README.md", "LICENSE"],
     "scripts": {
         "build": "bun -b tsdown",
         "prepublishOnly": "bun run build",

--- a/packages/mcp-connectors/src/connectors/documentation.ts
+++ b/packages/mcp-connectors/src/connectors/documentation.ts
@@ -278,7 +278,7 @@ export const DocumentationConnectorConfig = mcpConnectorConfig({
   setup: z.object({}),
   examplePrompt:
     'Find documentation for Anthropic Claude API authentication methods, then search for Prisma database schema migration best practices.',
-  logo: 'https://stackone-logos.com/api/stackone/filled/svg',
+  logo: 'https://stackone-logos.com/api/disco/filled/svg',
   tools: (tool) => ({
     GET_PROVIDER_KEY: tool({
       name: 'get_provider_key',

--- a/packages/mcp-connectors/src/connectors/exa.ts
+++ b/packages/mcp-connectors/src/connectors/exa.ts
@@ -193,7 +193,7 @@ const formatSearchResultsForLLM = (
 export const ExaConnectorConfig = mcpConnectorConfig({
   name: 'Exa',
   key: 'exa',
-  logo: 'https://exa.ai/favicon.ico',
+  logo: 'https://stackone-logos.com/api/exa/filled/svg',
   version: '1.0.0',
   credentials: z.object({
     apiKey: z.string().describe('Your Exa API key'),

--- a/packages/mcp-connectors/src/connectors/sequentialthinking.ts
+++ b/packages/mcp-connectors/src/connectors/sequentialthinking.ts
@@ -128,7 +128,7 @@ const processThought = (input: Record<string, unknown>): string => {
 export const SequentialThinkingConnectorConfig = mcpConnectorConfig({
   name: 'Sequential Thinking',
   key: 'sequential-thinking',
-  logo: 'https://stackone-logos.com/api/stackone/filled/svg',
+  logo: 'https://stackone-logos.com/api/disco/filled/svg',
   version: '1.0.0',
   credentials: z.object({}),
   setup: z.object({}),

--- a/packages/mcp-connectors/src/connectors/stackone.ts
+++ b/packages/mcp-connectors/src/connectors/stackone.ts
@@ -33,7 +33,9 @@ const searchDocumentation = async (keywords: string): Promise<string> => {
   const results = relevantChunks
     .map(
       (item, idx) =>
-        `### Search Result ${idx + 1} (Score: ${item.score.toFixed(2)})\n\n${item.chunk.trim()}`
+        `### Search Result ${idx + 1} (Score: ${item.score.toFixed(
+          2
+        )})\n\n${item.chunk.trim()}`
     )
     .join(`\n\n${'---'.repeat(20)}\n\n`);
 
@@ -119,7 +121,9 @@ export const StackOneConnectorConfig = mcpConnectorConfig({
         try {
           return await searchDocumentation(args.keywords);
         } catch (error) {
-          return `Error searching StackOne documentation: ${error instanceof Error ? error.message : 'Unknown error'}`;
+          return `Error searching StackOne documentation: ${
+            error instanceof Error ? error.message : 'Unknown error'
+          }`;
         }
       },
     }),

--- a/packages/mcp-connectors/src/connectors/test.ts
+++ b/packages/mcp-connectors/src/connectors/test.ts
@@ -11,7 +11,7 @@ export const TestConnectorConfig = mcpConnectorConfig({
   setup: z.object({
     someSetting: z.string().describe('Some setting'),
   }),
-  logo: 'https://stackone-logos.com/api/stackone/filled/svg',
+  logo: 'https://stackone-logos.com/api/disco/filled/svg',
   examplePrompt:
     'Test the connector by running basic tools, persisting some values, and incrementing a counter to verify functionality.',
   tools: (tool) => ({


### PR DESCRIPTION

    
<!-- This is an auto-generated description by cubic. -->

## Summary by cubic
Standardized connector logos to use the Disco logo service for consistent branding. Also aligned Exa’s logo source and added .npmrc to .gitignore.

- **Bug Fixes**
  - Documentation, Sequential Thinking, and Test connectors now use https://stackone-logos.com/api/disco/filled/svg.
  - Exa logo now served via https://stackone-logos.com/api/exa/filled/svg.
  - Minor formatting only; no behavior changes. Added .npmrc to .gitignore.

<!-- End of auto-generated description by cubic. -->

