### PR TITLE
fix: handle missing/undefined fields in parallel connector

### DIFF
--- a/packages/mcp-config-types/package.json
+++ b/packages/mcp-config-types/package.json
@@ -10,11 +10,7 @@
         "./package.json": "./package.json"
     },
     "type": "module",
-    "files": [
-        "dist",
-        "README.md",
-        "LICENSE"
-    ],
+    "files": ["dist", "README.md", "LICENSE"],
     "scripts": {
         "build": "bun -b tsdown",
         "prepublishOnly": "bun run build",

--- a/packages/mcp-connectors/package.json
+++ b/packages/mcp-connectors/package.json
@@ -10,11 +10,7 @@
         "./package.json": "./package.json"
     },
     "type": "module",
-    "files": [
-        "dist",
-        "README.md",
-        "LICENSE"
-    ],
+    "files": ["dist", "README.md", "LICENSE"],
     "scripts": {
         "build": "bun -b tsdown",
         "prepublishOnly": "bun run build",

--- a/packages/mcp-connectors/src/connectors/parallel.ts
+++ b/packages/mcp-connectors/src/connectors/parallel.ts
@@ -172,7 +172,13 @@ const formatSearchResults = (response: ParallelSearchResponse): string => {
       if (result.relevance_score) {
         output.push(`   Relevance: ${result.relevance_score}`);
       }
-      output.push(`   Content: ${result.content.substring(0, 200)}...`);
+      if (result.content) {
+        const contentPreview =
+          result.content.length > 200
+            ? `${result.content.substring(0, 200)}...`
+            : result.content;
+        output.push(`   Content: ${contentPreview}`);
+      }
       output.push(''); // Empty line between results
     }
   }
@@ -333,16 +339,20 @@ export const ParallelConnectorConfig = mcpConnectorConfig({
             args.maxTokens
           );
 
-          let output = result.response;
+          let output = result.response || 'No response received';
 
           if (result.sources && result.sources.length > 0) {
             output += '\n\nSources:\n';
             for (let i = 0; i < result.sources.length; i++) {
               const source = result.sources[i];
               if (source) {
-                output += `${i + 1}. ${source.title}\n`;
-                output += `   URL: ${source.url}\n`;
-                output += `   Snippet: ${source.snippet}\n\n`;
+                output += `${i + 1}. ${source.title || 'Untitled'}\n`;
+                output += `   URL: ${source.url || 'No URL'}\n`;
+                if (source.snippet) {
+                  output += `   Snippet: ${source.snippet}\n\n`;
+                } else {
+                  output += '\n';
+                }
               }
             }
           }


### PR DESCRIPTION
- Add null checks for result.content in formatSearchResults
- Handle missing response field in CHAT tool with fallback
- Add defensive checks for source fields (title, url, snippet)
- Add comprehensive test coverage for edge cases
- Fix potential substring errors on undefined values
    
<!-- This is an auto-generated description by cubic. -->
---

## Summary by cubic
Prevent crashes and bad output in the Parallel connector when the API returns missing fields. Adds safe fallbacks for content, response, and sources, with tests for these edge cases.

- **Bug Fixes**
  - Guard result.content before substring in search results; show up to 200 chars only when present.
  - CHAT: use "No response received" when response is missing.
  - Sources: default title to "Untitled", URL to "No URL", and omit snippet when absent.
  - Added tests for missing content, missing response, and incomplete source fields.

<!-- End of auto-generated description by cubic. -->

