### PR TITLE
feat: add CREATE_INTERNAL_ISSUE tool to Pylon connector

### DIFF
--- a/packages/mcp-config-types/package.json
+++ b/packages/mcp-config-types/package.json
@@ -10,11 +10,7 @@
         "./package.json": "./package.json"
     },
     "type": "module",
-    "files": [
-        "dist",
-        "README.md",
-        "LICENSE"
-    ],
+    "files": ["dist", "README.md", "LICENSE"],
     "scripts": {
         "build": "bun -b tsdown",
         "prepublishOnly": "bun run build",

--- a/packages/mcp-connectors/package.json
+++ b/packages/mcp-connectors/package.json
@@ -10,11 +10,7 @@
         "./package.json": "./package.json"
     },
     "type": "module",
-    "files": [
-        "dist",
-        "README.md",
-        "LICENSE"
-    ],
+    "files": ["dist", "README.md", "LICENSE"],
     "scripts": {
         "build": "bun -b tsdown",
         "prepublishOnly": "bun run build",


### PR DESCRIPTION
Implements the requested Create Internal Issue tool for the Pylon MCP connector.

## Changes
- Added `createIssue` method to PylonClient for POST /issues API
- Implemented `CREATE_INTERNAL_ISSUE` tool with complete Zod schema validation
- Supports all required and optional fields from Pylon API
- Includes proper error handling following existing patterns

Closes #34

Generated with [Claude Code](https://claude.ai/code)
    
<!-- This is an auto-generated description by cubic. -->
---

## Summary by cubic
Adds a CREATE_INTERNAL_ISSUE tool to the Pylon MCP connector so agents can create internal Pylon issues. Implements POST /issues with strict schema validation and consistent error handling (addresses #34).

- **New Features**
  - PylonClient.createIssue calls POST /issues.
  - Tool: pylon_create_internal_issue with Zod schema.
  - Supports title and body_html; optional: account_id, assignee_id, requester_email, requester_id, tags, priority, team_id, custom_fields.
  - Uses API token from credentials; returns created issue JSON.

- **Refactors**
  - Format package.json files to satisfy Biome.

<!-- End of auto-generated description by cubic. -->

