### PR TITLE
feat: add Strava MCP connector

### DIFF
--- a/packages/mcp-connectors/src/connectors/strava.spec.ts
+++ b/packages/mcp-connectors/src/connectors/strava.spec.ts
@@ -1,0 +1,478 @@
+import { describe, expect, it, vi } from 'vitest';
+import { http, HttpResponse } from 'msw';
+import { setupServer } from 'msw/node';
+import type { MCPToolDefinition } from '@stackone/mcp-config-types';
+import { createMockConnectorContext } from '../__mocks__/context';
+import { StravaConnectorConfig } from './strava';
+
+const server = setupServer();
+
+const mockAthlete = {
+  id: 123456,
+  firstname: 'John',
+  lastname: 'Doe',
+  profile_medium: 'https://example.com/profile.jpg',
+  profile: 'https://example.com/profile_large.jpg',
+  city: 'San Francisco',
+  state: 'CA',
+  country: 'US',
+  sex: 'M',
+  premium: true,
+  summit: true,
+  created_at: '2023-01-01T00:00:00Z',
+  updated_at: '2023-12-31T23:59:59Z',
+  follower_count: 100,
+  friend_count: 50,
+  ftp: 250,
+  weight: 75.0,
+  clubs: []
+};
+
+const mockActivity = {
+  id: 987654321,
+  name: 'Morning Ride',
+  distance: 32186.8,
+  moving_time: 4567,
+  elapsed_time: 4800,
+  total_elevation_gain: 314.2,
+  type: 'Ride',
+  start_date: '2023-12-25T08:00:00Z',
+  start_date_local: '2023-12-25T08:00:00',
+  timezone: 'America/Los_Angeles',
+  start_latlng: [37.7749, -122.4194],
+  end_latlng: [37.7849, -122.4094],
+  location_city: 'San Francisco',
+  location_state: 'CA',
+  location_country: 'US',
+  achievement_count: 2,
+  kudos_count: 15,
+  comment_count: 3,
+  athlete_count: 1,
+  photo_count: 2,
+  trainer: false,
+  commute: false,
+  manual: false,
+  private: false,
+  flagged: false,
+  gear_id: 'bike123',
+  average_speed: 7.05,
+  max_speed: 15.2,
+  has_heartrate: true,
+  average_heartrate: 145.5,
+  max_heartrate: 178,
+  heartrate_opt_out: false,
+  display_hide_heartrate_option: false,
+  elev_high: 52.3,
+  elev_low: 8.1,
+  upload_id: 111222333,
+  external_id: 'garmin_12345.fit',
+  from_accepted_tag: false,
+  pr_count: 1,
+  total_photo_count: 2,
+  has_kudoed: false
+};
+
+const mockSegment = {
+  id: 654321,
+  name: 'Lombard St Climb',
+  activity_type: 'Ride',
+  distance: 804.7,
+  average_grade: 8.3,
+  maximum_grade: 20.0,
+  elevation_high: 91.4,
+  elevation_low: 24.6,
+  start_latlng: [37.8021, -122.4194],
+  end_latlng: [37.8095, -122.4184],
+  climb_category: 4,
+  city: 'San Francisco',
+  state: 'CA',
+  country: 'US',
+  private: false,
+  hazardous: false,
+  starred: true,
+  effort_count: 50345,
+  athlete_count: 7453,
+  star_count: 632
+};
+
+describe('#StravaConnector', () => {
+  describe('.GET_ATHLETE', () => {
+    describe('when request is successful', () => {
+      it('returns athlete profile data', async () => {
+        server.use(
+          http.get('https://www.strava.com/api/v3/athlete', () => {
+            return HttpResponse.json(mockAthlete);
+          })
+        );
+
+        const tool = StravaConnectorConfig.tools.GET_ATHLETE as MCPToolDefinition;
+        const mockContext = createMockConnectorContext();
+        (mockContext.getCredentials as ReturnType<typeof vi.fn>).mockResolvedValue({ accessToken: 'test_token' });
+
+        const actual = await tool.handler({}, mockContext);
+
+        expect(actual).toBe(JSON.stringify(mockAthlete, null, 2));
+      });
+    });
+
+    describe('when request fails', () => {
+      it('returns error message', async () => {
+        server.use(
+          http.get('https://www.strava.com/api/v3/athlete', () => {
+            return HttpResponse.json({ message: 'Unauthorized' }, { status: 401 });
+          })
+        );
+
+        const tool = StravaConnectorConfig.tools.GET_ATHLETE as MCPToolDefinition;
+        const mockContext = createMockConnectorContext();
+        (mockContext.getCredentials as ReturnType<typeof vi.fn>).mockResolvedValue({ accessToken: 'invalid_token' });
+
+        const actual = await tool.handler({}, mockContext);
+
+        expect(actual).toContain('Failed to get athlete profile');
+      });
+    });
+  });
+
+  describe('.GET_ATHLETE_STATS', () => {
+    describe('when athlete ID is provided', () => {
+      it('returns athlete stats for specified ID', async () => {
+        const mockStats = {
+          recent_ride_totals: { count: 5, distance: 150000.0 },
+          ytd_ride_totals: { count: 150, distance: 5000000.0 }
+        };
+
+        server.use(
+          http.get('https://www.strava.com/api/v3/athletes/123456/stats', () => {
+            return HttpResponse.json(mockStats);
+          })
+        );
+
+        const tool = StravaConnectorConfig.tools.GET_ATHLETE_STATS as MCPToolDefinition;
+        const mockContext = createMockConnectorContext();
+        (mockContext.getCredentials as ReturnType<typeof vi.fn>).mockResolvedValue({ accessToken: 'test_token' });
+
+        const actual = await tool.handler({ athleteId: 123456 }, mockContext);
+
+        expect(actual).toBe(JSON.stringify(mockStats, null, 2));
+      });
+    });
+
+    describe('when no athlete ID is provided', () => {
+      it('fetches current athlete ID and returns stats', async () => {
+        const mockStats = {
+          recent_ride_totals: { count: 5, distance: 150000.0 },
+          ytd_ride_totals: { count: 150, distance: 5000000.0 }
+        };
+
+        server.use(
+          http.get('https://www.strava.com/api/v3/athlete', () => {
+            return HttpResponse.json(mockAthlete);
+          }),
+          http.get('https://www.strava.com/api/v3/athletes/123456/stats', () => {
+            return HttpResponse.json(mockStats);
+          })
+        );
+
+        const tool = StravaConnectorConfig.tools.GET_ATHLETE_STATS as MCPToolDefinition;
+        const mockContext = createMockConnectorContext();
+        (mockContext.getCredentials as ReturnType<typeof vi.fn>).mockResolvedValue({ accessToken: 'test_token' });
+
+        const actual = await tool.handler({}, mockContext);
+
+        expect(actual).toBe(JSON.stringify(mockStats, null, 2));
+      });
+    });
+  });
+
+  describe('.GET_ACTIVITIES', () => {
+    describe('when request is successful', () => {
+      it('returns list of activities', async () => {
+        const mockActivities = [mockActivity];
+
+        server.use(
+          http.get('https://www.strava.com/api/v3/athlete/activities', () => {
+            return HttpResponse.json(mockActivities);
+          })
+        );
+
+        const tool = StravaConnectorConfig.tools.GET_ACTIVITIES as MCPToolDefinition;
+        const mockContext = createMockConnectorContext();
+        (mockContext.getCredentials as ReturnType<typeof vi.fn>).mockResolvedValue({ accessToken: 'test_token' });
+
+        const actual = await tool.handler({}, mockContext);
+
+        expect(actual).toBe(JSON.stringify(mockActivities, null, 2));
+      });
+    });
+
+    describe('when pagination parameters are provided', () => {
+      it('includes pagination parameters in request', async () => {
+        server.use(
+          http.get('https://www.strava.com/api/v3/athlete/activities', ({ request }) => {
+            const url = new URL(request.url);
+            expect(url.searchParams.get('page')).toBe('2');
+            expect(url.searchParams.get('per_page')).toBe('10');
+            return HttpResponse.json([]);
+          })
+        );
+
+        const tool = StravaConnectorConfig.tools.GET_ACTIVITIES as MCPToolDefinition;
+        const mockContext = createMockConnectorContext();
+        (mockContext.getCredentials as ReturnType<typeof vi.fn>).mockResolvedValue({ accessToken: 'test_token' });
+
+        await tool.handler({ page: 2, perPage: 10 }, mockContext);
+      });
+    });
+  });
+
+  describe('.GET_ACTIVITY', () => {
+    describe('when activity exists', () => {
+      it('returns detailed activity information', async () => {
+        server.use(
+          http.get('https://www.strava.com/api/v3/activities/987654321', () => {
+            return HttpResponse.json(mockActivity);
+          })
+        );
+
+        const tool = StravaConnectorConfig.tools.GET_ACTIVITY as MCPToolDefinition;
+        const mockContext = createMockConnectorContext();
+        (mockContext.getCredentials as ReturnType<typeof vi.fn>).mockResolvedValue({ accessToken: 'test_token' });
+
+        const actual = await tool.handler({ activityId: 987654321 }, mockContext);
+
+        expect(actual).toBe(JSON.stringify(mockActivity, null, 2));
+      });
+    });
+
+    describe('when activity does not exist', () => {
+      it('returns error message', async () => {
+        server.use(
+          http.get('https://www.strava.com/api/v3/activities/999999', () => {
+            return HttpResponse.json({ message: 'Resource Not Found' }, { status: 404 });
+          })
+        );
+
+        const tool = StravaConnectorConfig.tools.GET_ACTIVITY as MCPToolDefinition;
+        const mockContext = createMockConnectorContext();
+        (mockContext.getCredentials as ReturnType<typeof vi.fn>).mockResolvedValue({ accessToken: 'test_token' });
+
+        const actual = await tool.handler({ activityId: 999999 }, mockContext);
+
+        expect(actual).toContain('Failed to get activity');
+      });
+    });
+  });
+
+  describe('.GET_ACTIVITY_STREAMS', () => {
+    describe('when activity has streams', () => {
+      it('returns stream data', async () => {
+        const mockStreams = {
+          time: { data: [0, 10, 20, 30] },
+          distance: { data: [0.0, 100.0, 200.0, 300.0] },
+          latlng: { data: [[37.7749, -122.4194], [37.7750, -122.4195]] }
+        };
+
+        server.use(
+          http.get('https://www.strava.com/api/v3/activities/987654321/streams', () => {
+            return HttpResponse.json(mockStreams);
+          })
+        );
+
+        const tool = StravaConnectorConfig.tools.GET_ACTIVITY_STREAMS as MCPToolDefinition;
+        const mockContext = createMockConnectorContext();
+        (mockContext.getCredentials as ReturnType<typeof vi.fn>).mockResolvedValue({ accessToken: 'test_token' });
+
+        const actual = await tool.handler({ activityId: 987654321 }, mockContext);
+
+        expect(actual).toBe(JSON.stringify(mockStreams, null, 2));
+      });
+    });
+
+    describe('when custom keys are provided', () => {
+      it('includes custom keys in request', async () => {
+        server.use(
+          http.get('https://www.strava.com/api/v3/activities/987654321/streams', ({ request }) => {
+            const url = new URL(request.url);
+            expect(url.searchParams.get('keys')).toBe('heartrate,watts');
+            return HttpResponse.json({});
+          })
+        );
+
+        const tool = StravaConnectorConfig.tools.GET_ACTIVITY_STREAMS as MCPToolDefinition;
+        const mockContext = createMockConnectorContext();
+        (mockContext.getCredentials as ReturnType<typeof vi.fn>).mockResolvedValue({ accessToken: 'test_token' });
+
+        await tool.handler({ activityId: 987654321, keys: ['heartrate', 'watts'] }, mockContext);
+      });
+    });
+  });
+
+  describe('.GET_SEGMENT', () => {
+    describe('when segment exists', () => {
+      it('returns segment information', async () => {
+        server.use(
+          http.get('https://www.strava.com/api/v3/segments/654321', () => {
+            return HttpResponse.json(mockSegment);
+          })
+        );
+
+        const tool = StravaConnectorConfig.tools.GET_SEGMENT as MCPToolDefinition;
+        const mockContext = createMockConnectorContext();
+        (mockContext.getCredentials as ReturnType<typeof vi.fn>).mockResolvedValue({ accessToken: 'test_token' });
+
+        const actual = await tool.handler({ segmentId: 654321 }, mockContext);
+
+        expect(actual).toBe(JSON.stringify(mockSegment, null, 2));
+      });
+    });
+  });
+
+  describe('.EXPLORE_SEGMENTS', () => {
+    describe('when bounds are provided', () => {
+      it('returns segments in the area', async () => {
+        const mockExploreResult = {
+          segments: [mockSegment]
+        };
+
+        server.use(
+          http.get('https://www.strava.com/api/v3/segments/explore', ({ request }) => {
+            const url = new URL(request.url);
+            expect(url.searchParams.get('bounds')).toBe('37.7,-122.5,37.8,-122.4');
+            expect(url.searchParams.get('activity_type')).toBe('riding');
+            return HttpResponse.json(mockExploreResult);
+          })
+        );
+
+        const tool = StravaConnectorConfig.tools.EXPLORE_SEGMENTS as MCPToolDefinition;
+        const mockContext = createMockConnectorContext();
+        (mockContext.getCredentials as ReturnType<typeof vi.fn>).mockResolvedValue({ accessToken: 'test_token' });
+
+        const actual = await tool.handler({
+          bounds: {
+            sw: [37.7, -122.5],
+            ne: [37.8, -122.4]
+          }
+        }, mockContext);
+
+        expect(actual).toBe(JSON.stringify(mockExploreResult, null, 2));
+      });
+    });
+
+    describe('when activity type is running', () => {
+      it('sets activity_type parameter to running', async () => {
+        server.use(
+          http.get('https://www.strava.com/api/v3/segments/explore', ({ request }) => {
+            const url = new URL(request.url);
+            expect(url.searchParams.get('activity_type')).toBe('running');
+            return HttpResponse.json({ segments: [] });
+          })
+        );
+
+        const tool = StravaConnectorConfig.tools.EXPLORE_SEGMENTS as MCPToolDefinition;
+        const mockContext = createMockConnectorContext();
+        (mockContext.getCredentials as ReturnType<typeof vi.fn>).mockResolvedValue({ accessToken: 'test_token' });
+
+        await tool.handler({
+          bounds: {
+            sw: [37.7, -122.5],
+            ne: [37.8, -122.4]
+          },
+          activityType: 'running'
+        }, mockContext);
+      });
+    });
+  });
+
+  describe('.GET_ATHLETE_ROUTES', () => {
+    describe('when request is successful', () => {
+      it('returns list of routes', async () => {
+        const mockRoutes = [{
+          id: 456789,
+          name: 'Golden Gate Loop',
+          description: 'Beautiful route around the Golden Gate',
+          distance: 25000.0,
+          elevation_gain: 500.0,
+          type: 1,
+          sub_type: 1,
+          private: false,
+          starred: true,
+          timestamp: 1640995200,
+          segments: []
+        }];
+
+        server.use(
+          http.get('https://www.strava.com/api/v3/athletes/routes', () => {
+            return HttpResponse.json(mockRoutes);
+          })
+        );
+
+        const tool = StravaConnectorConfig.tools.GET_ATHLETE_ROUTES as MCPToolDefinition;
+        const mockContext = createMockConnectorContext();
+        (mockContext.getCredentials as ReturnType<typeof vi.fn>).mockResolvedValue({ accessToken: 'test_token' });
+
+        const actual = await tool.handler({}, mockContext);
+
+        expect(actual).toBe(JSON.stringify(mockRoutes, null, 2));
+      });
+    });
+  });
+
+  describe('.GET_ROUTE', () => {
+    describe('when route exists', () => {
+      it('returns route information', async () => {
+        const mockRoute = {
+          id: 456789,
+          name: 'Golden Gate Loop',
+          description: 'Beautiful route around the Golden Gate',
+          distance: 25000.0,
+          elevation_gain: 500.0,
+          type: 1,
+          sub_type: 1,
+          private: false,
+          starred: true,
+          timestamp: 1640995200,
+          segments: []
+        };
+
+        server.use(
+          http.get('https://www.strava.com/api/v3/routes/456789', () => {
+            return HttpResponse.json(mockRoute);
+          })
+        );
+
+        const tool = StravaConnectorConfig.tools.GET_ROUTE as MCPToolDefinition;
+        const mockContext = createMockConnectorContext();
+        (mockContext.getCredentials as ReturnType<typeof vi.fn>).mockResolvedValue({ accessToken: 'test_token' });
+
+        const actual = await tool.handler({ routeId: 456789 }, mockContext);
+
+        expect(actual).toBe(JSON.stringify(mockRoute, null, 2));
+      });
+    });
+  });
+
+  describe('.GET_STARRED_SEGMENTS', () => {
+    describe('when request is successful', () => {
+      it('returns list of starred segments', async () => {
+        const mockStarredSegments = [mockSegment];
+
+        server.use(
+          http.get('https://www.strava.com/api/v3/segments/starred', () => {
+            return HttpResponse.json(mockStarredSegments);
+          })
+        );
+
+        const tool = StravaConnectorConfig.tools.GET_STARRED_SEGMENTS as MCPToolDefinition;
+        const mockContext = createMockConnectorContext();
+        (mockContext.getCredentials as ReturnType<typeof vi.fn>).mockResolvedValue({ accessToken: 'test_token' });
+
+        const actual = await tool.handler({}, mockContext);
+
+        expect(actual).toBe(JSON.stringify(mockStarredSegments, null, 2));
+      });
+    });
+  });
+});
+
+server.listen({ onUnhandledRequest: 'error' });

--- a/packages/mcp-connectors/src/connectors/strava.ts
+++ b/packages/mcp-connectors/src/connectors/strava.ts
@@ -1,0 +1,579 @@
+import { mcpConnectorConfig } from '@stackone/mcp-config-types';
+import { z } from 'zod';
+
+interface StravaAthlete {
+  id: number;
+  firstname: string;
+  lastname: string;
+  profile_medium: string;
+  profile: string;
+  city: string;
+  state: string;
+  country: string;
+  sex: string;
+  premium: boolean;
+  summit: boolean;
+  created_at: string;
+  updated_at: string;
+  follower_count: number;
+  friend_count: number;
+  ftp: number;
+  weight: number;
+  clubs: Array<{
+    id: number;
+    name: string;
+    profile_medium: string;
+  }>;
+}
+
+interface StravaActivity {
+  id: number;
+  name: string;
+  distance: number;
+  moving_time: number;
+  elapsed_time: number;
+  total_elevation_gain: number;
+  type: string;
+  start_date: string;
+  start_date_local: string;
+  timezone: string;
+  start_latlng: [number, number] | null;
+  end_latlng: [number, number] | null;
+  location_city: string;
+  location_state: string;
+  location_country: string;
+  achievement_count: number;
+  kudos_count: number;
+  comment_count: number;
+  athlete_count: number;
+  photo_count: number;
+  trainer: boolean;
+  commute: boolean;
+  manual: boolean;
+  private: boolean;
+  flagged: boolean;
+  gear_id: string;
+  average_speed: number;
+  max_speed: number;
+  has_heartrate: boolean;
+  average_heartrate?: number;
+  max_heartrate?: number;
+  heartrate_opt_out: boolean;
+  display_hide_heartrate_option: boolean;
+  elev_high: number;
+  elev_low: number;
+  upload_id: number;
+  external_id: string;
+  from_accepted_tag: boolean;
+  pr_count: number;
+  total_photo_count: number;
+  has_kudoed: boolean;
+}
+
+interface StravaSegment {
+  id: number;
+  name: string;
+  activity_type: string;
+  distance: number;
+  average_grade: number;
+  maximum_grade: number;
+  elevation_high: number;
+  elevation_low: number;
+  start_latlng: [number, number];
+  end_latlng: [number, number];
+  climb_category: number;
+  city: string;
+  state: string;
+  country: string;
+  private: boolean;
+  hazardous: boolean;
+  starred: boolean;
+  pr_time?: number;
+  effort_count: number;
+  athlete_count: number;
+  star_count: number;
+}
+
+interface StravaRoute {
+  id: number;
+  name: string;
+  description: string;
+  distance: number;
+  elevation_gain: number;
+  type: number;
+  sub_type: number;
+  private: boolean;
+  starred: boolean;
+  timestamp: number;
+  segments: StravaSegment[];
+}
+
+interface StravaAthleteStats {
+  biggest_ride_distance: number;
+  biggest_climb_elevation_gain: number;
+  recent_ride_totals: {
+    count: number;
+    distance: number;
+    moving_time: number;
+    elapsed_time: number;
+    elevation_gain: number;
+    achievement_count: number;
+  };
+  recent_run_totals: {
+    count: number;
+    distance: number;
+    moving_time: number;
+    elapsed_time: number;
+    elevation_gain: number;
+    achievement_count: number;
+  };
+  recent_swim_totals: {
+    count: number;
+    distance: number;
+    moving_time: number;
+    elapsed_time: number;
+    elevation_gain: number;
+    achievement_count: number;
+  };
+  ytd_ride_totals: {
+    count: number;
+    distance: number;
+    moving_time: number;
+    elapsed_time: number;
+    elevation_gain: number;
+  };
+  ytd_run_totals: {
+    count: number;
+    distance: number;
+    moving_time: number;
+    elapsed_time: number;
+    elevation_gain: number;
+  };
+  ytd_swim_totals: {
+    count: number;
+    distance: number;
+    moving_time: number;
+    elapsed_time: number;
+    elevation_gain: number;
+  };
+  all_ride_totals: {
+    count: number;
+    distance: number;
+    moving_time: number;
+    elapsed_time: number;
+    elevation_gain: number;
+  };
+  all_run_totals: {
+    count: number;
+    distance: number;
+    moving_time: number;
+    elapsed_time: number;
+    elevation_gain: number;
+  };
+  all_swim_totals: {
+    count: number;
+    distance: number;
+    moving_time: number;
+    elapsed_time: number;
+    elevation_gain: number;
+  };
+}
+
+class StravaClient {
+  private headers: { Authorization: string; Accept: string };
+  private baseUrl = 'https://www.strava.com/api/v3';
+
+  constructor(accessToken: string) {
+    this.headers = {
+      Authorization: `Bearer ${accessToken}`,
+      Accept: 'application/json',
+    };
+  }
+
+  async getAthlete(): Promise<StravaAthlete> {
+    const response = await fetch(`${this.baseUrl}/athlete`, {
+      headers: this.headers,
+    });
+
+    if (!response.ok) {
+      throw new Error(`Strava API error: ${response.status} ${response.statusText}`);
+    }
+
+    return response.json() as Promise<StravaAthlete>;
+  }
+
+  async getAthleteStats(athleteId: number): Promise<StravaAthleteStats> {
+    const response = await fetch(`${this.baseUrl}/athletes/${athleteId}/stats`, {
+      headers: this.headers,
+    });
+
+    if (!response.ok) {
+      throw new Error(`Strava API error: ${response.status} ${response.statusText}`);
+    }
+
+    return response.json() as Promise<StravaAthleteStats>;
+  }
+
+  async getActivities(
+    before?: number,
+    after?: number,
+    page = 1,
+    perPage = 30
+  ): Promise<StravaActivity[]> {
+    const params = new URLSearchParams({
+      page: page.toString(),
+      per_page: perPage.toString(),
+    });
+
+    if (before) params.set('before', before.toString());
+    if (after) params.set('after', after.toString());
+
+    const response = await fetch(`${this.baseUrl}/athlete/activities?${params}`, {
+      headers: this.headers,
+    });
+
+    if (!response.ok) {
+      throw new Error(`Strava API error: ${response.status} ${response.statusText}`);
+    }
+
+    return response.json() as Promise<StravaActivity[]>;
+  }
+
+  async getActivity(activityId: number): Promise<StravaActivity> {
+    const response = await fetch(`${this.baseUrl}/activities/${activityId}`, {
+      headers: this.headers,
+    });
+
+    if (!response.ok) {
+      throw new Error(`Strava API error: ${response.status} ${response.statusText}`);
+    }
+
+    return response.json() as Promise<StravaActivity>;
+  }
+
+  async getActivityStreams(
+    activityId: number,
+    keys: string[] = ['time', 'distance', 'latlng', 'altitude', 'heartrate', 'watts']
+  ): Promise<any> {
+    const keysString = keys.join(',');
+    const response = await fetch(
+      `${this.baseUrl}/activities/${activityId}/streams?keys=${keysString}&key_by_type=true`,
+      {
+        headers: this.headers,
+      }
+    );
+
+    if (!response.ok) {
+      throw new Error(`Strava API error: ${response.status} ${response.statusText}`);
+    }
+
+    return response.json();
+  }
+
+  async getSegment(segmentId: number): Promise<StravaSegment> {
+    const response = await fetch(`${this.baseUrl}/segments/${segmentId}`, {
+      headers: this.headers,
+    });
+
+    if (!response.ok) {
+      throw new Error(`Strava API error: ${response.status} ${response.statusText}`);
+    }
+
+    return response.json() as Promise<StravaSegment>;
+  }
+
+  async exploreSegments(
+    bounds: { sw: [number, number]; ne: [number, number] },
+    activityType: 'running' | 'riding' = 'riding',
+    minCategory = 0,
+    maxCategory = 5
+  ): Promise<{ segments: StravaSegment[] }> {
+    const boundsString = `${bounds.sw[0]},${bounds.sw[1]},${bounds.ne[0]},${bounds.ne[1]}`;
+    const response = await fetch(
+      `${this.baseUrl}/segments/explore?bounds=${boundsString}&activity_type=${activityType}&min_cat=${minCategory}&max_cat=${maxCategory}`,
+      {
+        headers: this.headers,
+      }
+    );
+
+    if (!response.ok) {
+      throw new Error(`Strava API error: ${response.status} ${response.statusText}`);
+    }
+
+    return response.json() as Promise<{ segments: StravaSegment[] }>;
+  }
+
+  async getAthleteRoutes(page = 1, perPage = 30): Promise<StravaRoute[]> {
+    const response = await fetch(
+      `${this.baseUrl}/athletes/routes?page=${page}&per_page=${perPage}`,
+      {
+        headers: this.headers,
+      }
+    );
+
+    if (!response.ok) {
+      throw new Error(`Strava API error: ${response.status} ${response.statusText}`);
+    }
+
+    return response.json() as Promise<StravaRoute[]>;
+  }
+
+  async getRoute(routeId: number): Promise<StravaRoute> {
+    const response = await fetch(`${this.baseUrl}/routes/${routeId}`, {
+      headers: this.headers,
+    });
+
+    if (!response.ok) {
+      throw new Error(`Strava API error: ${response.status} ${response.statusText}`);
+    }
+
+    return response.json() as Promise<StravaRoute>;
+  }
+
+  async getStarredSegments(page = 1, perPage = 30): Promise<StravaSegment[]> {
+    const response = await fetch(
+      `${this.baseUrl}/segments/starred?page=${page}&per_page=${perPage}`,
+      {
+        headers: this.headers,
+      }
+    );
+
+    if (!response.ok) {
+      throw new Error(`Strava API error: ${response.status} ${response.statusText}`);
+    }
+
+    return response.json() as Promise<StravaSegment[]>;
+  }
+}
+
+export const StravaConnectorConfig = mcpConnectorConfig({
+  name: 'Strava',
+  key: 'strava',
+  version: '1.0.0',
+  logo: 'https://stackone-logos.com/api/strava/filled/svg',
+  credentials: z.object({
+    accessToken: z
+      .string()
+      .describe(
+        'Strava Access Token obtained through OAuth 2.0 flow :: 1234567890abcdef :: https://developers.strava.com/docs/getting-started'
+      ),
+  }),
+  setup: z.object({}),
+  examplePrompt:
+    'Get my recent activities from Strava, show my athlete profile and statistics, and find popular cycling segments in my area.',
+  tools: (tool) => ({
+    GET_ATHLETE: tool({
+      name: 'strava_get_athlete',
+      description: 'Get the authenticated athlete profile information',
+      schema: z.object({}),
+      handler: async (_args, context) => {
+        try {
+          const { accessToken } = await context.getCredentials();
+          const client = new StravaClient(accessToken);
+          const athlete = await client.getAthlete();
+          return JSON.stringify(athlete, null, 2);
+        } catch (error) {
+          return `Failed to get athlete profile: ${error instanceof Error ? error.message : String(error)}`;
+        }
+      },
+    }),
+    GET_ATHLETE_STATS: tool({
+      name: 'strava_get_athlete_stats',
+      description: 'Get statistics for the authenticated athlete',
+      schema: z.object({
+        athleteId: z.number().optional().describe('Athlete ID (defaults to authenticated athlete)'),
+      }),
+      handler: async (args, context) => {
+        try {
+          const { accessToken } = await context.getCredentials();
+          const client = new StravaClient(accessToken);
+          
+          let athleteId = args.athleteId;
+          if (!athleteId) {
+            const athlete = await client.getAthlete();
+            athleteId = athlete.id;
+          }
+          
+          const stats = await client.getAthleteStats(athleteId);
+          return JSON.stringify(stats, null, 2);
+        } catch (error) {
+          return `Failed to get athlete stats: ${error instanceof Error ? error.message : String(error)}`;
+        }
+      },
+    }),
+    GET_ACTIVITIES: tool({
+      name: 'strava_get_activities',
+      description: 'Get recent activities for the authenticated athlete',
+      schema: z.object({
+        before: z.number().optional().describe('Unix timestamp to retrieve activities before'),
+        after: z.number().optional().describe('Unix timestamp to retrieve activities after'),
+        page: z.number().default(1).describe('Page number for pagination'),
+        perPage: z.number().default(30).describe('Number of activities per page (max 200)'),
+      }),
+      handler: async (args, context) => {
+        try {
+          const { accessToken } = await context.getCredentials();
+          const client = new StravaClient(accessToken);
+          const activities = await client.getActivities(
+            args.before,
+            args.after,
+            args.page,
+            args.perPage
+          );
+          return JSON.stringify(activities, null, 2);
+        } catch (error) {
+          return `Failed to get activities: ${error instanceof Error ? error.message : String(error)}`;
+        }
+      },
+    }),
+    GET_ACTIVITY: tool({
+      name: 'strava_get_activity',
+      description: 'Get detailed information about a specific activity',
+      schema: z.object({
+        activityId: z.number().describe('The ID of the activity'),
+      }),
+      handler: async (args, context) => {
+        try {
+          const { accessToken } = await context.getCredentials();
+          const client = new StravaClient(accessToken);
+          const activity = await client.getActivity(args.activityId);
+          return JSON.stringify(activity, null, 2);
+        } catch (error) {
+          return `Failed to get activity: ${error instanceof Error ? error.message : String(error)}`;
+        }
+      },
+    }),
+    GET_ACTIVITY_STREAMS: tool({
+      name: 'strava_get_activity_streams',
+      description: 'Get detailed stream data for an activity (GPS, heart rate, power, etc.)',
+      schema: z.object({
+        activityId: z.number().describe('The ID of the activity'),
+        keys: z
+          .array(z.string())
+          .optional()
+          .describe('Stream types to retrieve: time, distance, latlng, altitude, heartrate, watts, etc.'),
+      }),
+      handler: async (args, context) => {
+        try {
+          const { accessToken } = await context.getCredentials();
+          const client = new StravaClient(accessToken);
+          const streams = await client.getActivityStreams(args.activityId, args.keys);
+          return JSON.stringify(streams, null, 2);
+        } catch (error) {
+          return `Failed to get activity streams: ${error instanceof Error ? error.message : String(error)}`;
+        }
+      },
+    }),
+    GET_SEGMENT: tool({
+      name: 'strava_get_segment',
+      description: 'Get information about a specific segment',
+      schema: z.object({
+        segmentId: z.number().describe('The ID of the segment'),
+      }),
+      handler: async (args, context) => {
+        try {
+          const { accessToken } = await context.getCredentials();
+          const client = new StravaClient(accessToken);
+          const segment = await client.getSegment(args.segmentId);
+          return JSON.stringify(segment, null, 2);
+        } catch (error) {
+          return `Failed to get segment: ${error instanceof Error ? error.message : String(error)}`;
+        }
+      },
+    }),
+    EXPLORE_SEGMENTS: tool({
+      name: 'strava_explore_segments',
+      description: 'Find popular segments in a geographic area',
+      schema: z.object({
+        bounds: z.object({
+          sw: z.tuple([z.number(), z.number()]).describe('Southwest corner [lat, lng]'),
+          ne: z.tuple([z.number(), z.number()]).describe('Northeast corner [lat, lng]'),
+        }).describe('Bounding box for the search area'),
+        activityType: z
+          .enum(['running', 'riding'])
+          .default('riding')
+          .describe('Type of activity to search for'),
+        minCategory: z
+          .number()
+          .min(0)
+          .max(5)
+          .default(0)
+          .describe('Minimum climb category (0-5)'),
+        maxCategory: z
+          .number()
+          .min(0)
+          .max(5)
+          .default(5)
+          .describe('Maximum climb category (0-5)'),
+      }),
+      handler: async (args, context) => {
+        try {
+          const { accessToken } = await context.getCredentials();
+          const client = new StravaClient(accessToken);
+          const result = await client.exploreSegments(
+            args.bounds,
+            args.activityType,
+            args.minCategory,
+            args.maxCategory
+          );
+          return JSON.stringify(result, null, 2);
+        } catch (error) {
+          return `Failed to explore segments: ${error instanceof Error ? error.message : String(error)}`;
+        }
+      },
+    }),
+    GET_ATHLETE_ROUTES: tool({
+      name: 'strava_get_athlete_routes',
+      description: 'Get routes created by the authenticated athlete',
+      schema: z.object({
+        page: z.number().default(1).describe('Page number for pagination'),
+        perPage: z.number().default(30).describe('Number of routes per page'),
+      }),
+      handler: async (args, context) => {
+        try {
+          const { accessToken } = await context.getCredentials();
+          const client = new StravaClient(accessToken);
+          const routes = await client.getAthleteRoutes(args.page, args.perPage);
+          return JSON.stringify(routes, null, 2);
+        } catch (error) {
+          return `Failed to get athlete routes: ${error instanceof Error ? error.message : String(error)}`;
+        }
+      },
+    }),
+    GET_ROUTE: tool({
+      name: 'strava_get_route',
+      description: 'Get detailed information about a specific route',
+      schema: z.object({
+        routeId: z.number().describe('The ID of the route'),
+      }),
+      handler: async (args, context) => {
+        try {
+          const { accessToken } = await context.getCredentials();
+          const client = new StravaClient(accessToken);
+          const route = await client.getRoute(args.routeId);
+          return JSON.stringify(route, null, 2);
+        } catch (error) {
+          return `Failed to get route: ${error instanceof Error ? error.message : String(error)}`;
+        }
+      },
+    }),
+    GET_STARRED_SEGMENTS: tool({
+      name: 'strava_get_starred_segments',
+      description: 'Get segments that the authenticated athlete has starred',
+      schema: z.object({
+        page: z.number().default(1).describe('Page number for pagination'),
+        perPage: z.number().default(30).describe('Number of segments per page'),
+      }),
+      handler: async (args, context) => {
+        try {
+          const { accessToken } = await context.getCredentials();
+          const client = new StravaClient(accessToken);
+          const segments = await client.getStarredSegments(args.page, args.perPage);
+          return JSON.stringify(segments, null, 2);
+        } catch (error) {
+          return `Failed to get starred segments: ${error instanceof Error ? error.message : String(error)}`;
+        }
+      },
+    }),
+  }),
+});

--- a/packages/mcp-connectors/src/index.ts
+++ b/packages/mcp-connectors/src/index.ts
@@ -31,6 +31,7 @@ import { ReplicateConnectorConfig } from './connectors/replicate';
 import { SequentialThinkingConnectorConfig } from './connectors/sequential-thinking';
 import { SlackConnectorConfig } from './connectors/slack';
 import { StackOneConnectorConfig } from './connectors/stackone';
+import { StravaConnectorConfig } from './connectors/strava';
 import { SupabaseConnectorConfig } from './connectors/supabase';
 import { TestConnectorConfig } from './connectors/test';
 import { TinybirdConnectorConfig } from './connectors/tinybird';
@@ -71,6 +72,7 @@ export const Connectors: readonly MCPConnectorConfig[] = [
   ReplicateConnectorConfig,
   SequentialThinkingConnectorConfig,
   SlackConnectorConfig,
+  StravaConnectorConfig,
   SupabaseConnectorConfig,
   TinybirdConnectorConfig,
   TodoistConnectorConfig,
@@ -111,6 +113,7 @@ export {
   ReplicateConnectorConfig,
   SequentialThinkingConnectorConfig,
   SlackConnectorConfig,
+  StravaConnectorConfig,
   SupabaseConnectorConfig,
   TinybirdConnectorConfig,
   TodoistConnectorConfig,


### PR DESCRIPTION
Add comprehensive Strava integration based on https://github.com/r-huijts/strava-mcp

Implemented 10 tools covering:
- Athlete profiles and statistics
- Activity listing and detailed data
- Activity streams (GPS, heart rate, power)
- Segment exploration and management
- Route management
- Starred segments

Features:
- OAuth 2.0 authentication
- Full TypeScript typing
- Zod schema validation
- Comprehensive test coverage (16 tests)
- Error handling and pagination support

Closes #45

Generated with [Claude Code](https://claude.ai/code)