### PR TITLE
ci: use lts node

### DIFF
--- a/.github/workflows/claude.yml
+++ b/.github/workflows/claude.yml
@@ -36,7 +36,7 @@ jobs:
       - name: Setup Node.js
         uses: actions/setup-node@v4
         with:
-          node-version: "20"
+          node-version: lts/*
 
       - name: Install bun
         uses: oven-sh/setup-bun@v2

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -40,7 +40,7 @@ jobs:
       - name: Setup Node.js for npm
         uses: actions/setup-node@v4
         with:
-          node-version: "22"
+          node-version: lts/*
           registry-url: "https://registry.npmjs.org"
 
       - name: 💫 Install dependencies


### PR DESCRIPTION

    
<!-- This is an auto-generated description by cubic. -->

## Summary by cubic
Switch CI to Node.js LTS to keep builds stable and reduce maintenance. Replaces pinned versions (20, 22) with lts/* in claude.yml and release.yml.

<!-- End of auto-generated description by cubic. -->

