### PR TITLE
ci: add ryoppippi and maintainable conditions

### DIFF
--- a/.github/workflows/claude.yml
+++ b/.github/workflows/claude.yml
@@ -12,14 +12,20 @@ on:
 
 jobs:
   claude:
-    # Only run when mattzcarey tags @claude
-    if: |
-      (github.actor == 'mattzcarey' || github.actor == 'willleeney' || github.actor == 'brycetoz' || github.actor == 'glebedel') && (
-        (github.event_name == 'issue_comment' && contains(github.event.comment.body, '@claude')) ||
-        (github.event_name == 'pull_request_review_comment' && contains(github.event.comment.body, '@claude')) ||
-        (github.event_name == 'pull_request_review' && contains(github.event.review.body, '@claude')) ||
-        (github.event_name == 'issues' && (contains(github.event.issue.body, '@claude') || contains(github.event.issue.title, '@claude')))
-      )
+    # Only run when stackone team and tags @claude
+    if: >
+      contains(fromJSON('["mattzcarey","willleeney","brycetoz","glebedel","ryoppippi"]'), github.actor)
+      && contains(fromJSON('["issue_comment","pull_request_review_comment","pull_request_review","issues"]'), github.event_name)
+      && contains(
+           format(
+             '{0}\n{1}\n{2}\n{3}',
+             github.event.comment.body || '',
+             github.event.review.body || '',
+             github.event.issue.body || '',
+             github.event.issue.title || ''
+           ),
+           '@claude'
+         )
     runs-on: ubuntu-latest
     permissions:
       contents: write


### PR DESCRIPTION

    
<!-- This is an auto-generated description by cubic. -->

## Summary by cubic
Make the claude workflow easier to maintain and add ryoppippi to the allowed actors. The job still runs only when an allowed user mentions @claude in comments, reviews, or issues.

- **New Features**
  - Added ryoppippi to the allowed actors list.

- **Refactors**
  - Replaced nested if with lists via fromJSON for actors and event types.
  - Unified mention check across comment, review, issue body, and title.
  - Default missing fields to empty strings to avoid null errors.

<!-- End of auto-generated description by cubic. -->

