### PR TITLE
feat: add npm connector for package search and metadata

### DIFF
--- a/packages/mcp-connectors/src/connectors/npm.spec.ts
+++ b/packages/mcp-connectors/src/connectors/npm.spec.ts
@@ -1,7 +1,7 @@
 import type { MCPToolDefinition } from '@stackone/mcp-config-types';
 import { http, HttpResponse } from 'msw';
 import { setupServer } from 'msw/node';
-import { describe, expect, it } from 'vitest';
+import { afterEach, beforeEach, describe, expect, it } from 'vitest';
 import { createMockConnectorContext } from '../__mocks__/context';
 import { NpmConnectorConfig } from './npm';
 
@@ -186,6 +186,14 @@ const mockVersionResponse = {
 const server = setupServer();
 
 describe('#NpmConnectorConfig', () => {
+  beforeEach(() => {
+    server.listen({ onUnhandledRequest: 'error' });
+  });
+
+  afterEach(() => {
+    server.resetHandlers();
+    server.close();
+  });
   describe('.SEARCH_PACKAGES', () => {
     describe('when search is successful', () => {
       describe('and packages are found', () => {
@@ -203,8 +211,6 @@ describe('#NpmConnectorConfig', () => {
             })
           );
 
-          server.listen();
-
           const tool = NpmConnectorConfig.tools.SEARCH_PACKAGES as MCPToolDefinition;
           const mockContext = createMockConnectorContext();
 
@@ -218,8 +224,6 @@ describe('#NpmConnectorConfig', () => {
           expect(actual).toContain('Score: 0.95');
           expect(actual).toContain('https://npmjs.com/package/test-package');
           expect(actual).toContain('2. another-package@2.1.0');
-
-          server.close();
         });
       });
 
@@ -236,14 +240,10 @@ describe('#NpmConnectorConfig', () => {
             })
           );
 
-          server.listen();
-
           const tool = NpmConnectorConfig.tools.SEARCH_PACKAGES as MCPToolDefinition;
           const mockContext = createMockConnectorContext();
 
           await tool.handler({ query: 'test', size: 5 }, mockContext);
-
-          server.close();
         });
       });
 
@@ -259,16 +259,12 @@ describe('#NpmConnectorConfig', () => {
             })
           );
 
-          server.listen();
-
           const tool = NpmConnectorConfig.tools.SEARCH_PACKAGES as MCPToolDefinition;
           const mockContext = createMockConnectorContext();
 
           const actual = await tool.handler({ query: 'nonexistent' }, mockContext);
 
           expect(actual).toBe('No packages found for your search query.');
-
-          server.close();
         });
       });
     });
@@ -285,8 +281,6 @@ describe('#NpmConnectorConfig', () => {
             })
           );
 
-          server.listen();
-
           const tool = NpmConnectorConfig.tools.SEARCH_PACKAGES as MCPToolDefinition;
           const mockContext = createMockConnectorContext();
 
@@ -294,8 +288,6 @@ describe('#NpmConnectorConfig', () => {
 
           expect(actual).toContain('An error occurred while searching packages');
           expect(actual).toContain('HTTP error! Status: 500');
-
-          server.close();
         });
       });
     });
@@ -310,8 +302,6 @@ describe('#NpmConnectorConfig', () => {
               return HttpResponse.json(mockPackageResponse);
             })
           );
-
-          server.listen();
 
           const tool = NpmConnectorConfig.tools.GET_PACKAGE_INFO as MCPToolDefinition;
           const mockContext = createMockConnectorContext();
@@ -330,15 +320,13 @@ describe('#NpmConnectorConfig', () => {
           );
           expect(actual).toContain('Maintainers: testuser');
           expect(actual).toContain('https://npmjs.com/package/test-package');
-
-          server.close();
         });
       });
 
       describe('and package name contains special characters', () => {
         it('properly encodes the package name', async () => {
           server.use(
-            http.get('https://registry.npmjs.org/@types%2Fnode', () => {
+            http.get('https://registry.npmjs.org/%40types%2Fnode', () => {
               return HttpResponse.json({
                 ...mockPackageResponse,
                 name: '@types/node',
@@ -347,16 +335,12 @@ describe('#NpmConnectorConfig', () => {
             })
           );
 
-          server.listen();
-
           const tool = NpmConnectorConfig.tools.GET_PACKAGE_INFO as MCPToolDefinition;
           const mockContext = createMockConnectorContext();
 
           const actual = await tool.handler({ packageName: '@types/node' }, mockContext);
 
           expect(actual).toContain('Package Information for @types/node:');
-
-          server.close();
         });
       });
     });
@@ -370,8 +354,6 @@ describe('#NpmConnectorConfig', () => {
             })
           );
 
-          server.listen();
-
           const tool = NpmConnectorConfig.tools.GET_PACKAGE_INFO as MCPToolDefinition;
           const mockContext = createMockConnectorContext();
 
@@ -382,8 +364,6 @@ describe('#NpmConnectorConfig', () => {
 
           expect(actual).toContain('An error occurred while getting package info');
           expect(actual).toContain('Package "nonexistent-package" not found');
-
-          server.close();
         });
       });
     });
@@ -398,8 +378,6 @@ describe('#NpmConnectorConfig', () => {
               return HttpResponse.json(mockVersionResponse);
             })
           );
-
-          server.listen();
 
           const tool = NpmConnectorConfig.tools.GET_VERSION_INFO as MCPToolDefinition;
           const mockContext = createMockConnectorContext();
@@ -419,10 +397,8 @@ describe('#NpmConnectorConfig', () => {
           expect(actual).toContain('lodash: ^4.17.21');
           expect(actual).toContain('axios: ^0.27.2');
           expect(actual).toContain('Dev Dependencies: 2 packages');
-          expect(actual).toContain('Peer Dependencies: 1 packages');
+          expect(actual).toContain('Peer Dependencies: 1 package');
           expect(actual).toContain('https://npmjs.com/package/test-package/v/1.2.3');
-
-          server.close();
         });
       });
 
@@ -434,16 +410,12 @@ describe('#NpmConnectorConfig', () => {
             })
           );
 
-          server.listen();
-
           const tool = NpmConnectorConfig.tools.GET_VERSION_INFO as MCPToolDefinition;
           const mockContext = createMockConnectorContext();
 
           const actual = await tool.handler({ packageName: 'test-package' }, mockContext);
 
           expect(actual).toContain('Version Information for test-package@1.2.3:');
-
-          server.close();
         });
       });
     });
@@ -457,8 +429,6 @@ describe('#NpmConnectorConfig', () => {
             })
           );
 
-          server.listen();
-
           const tool = NpmConnectorConfig.tools.GET_VERSION_INFO as MCPToolDefinition;
           const mockContext = createMockConnectorContext();
 
@@ -469,8 +439,6 @@ describe('#NpmConnectorConfig', () => {
 
           expect(actual).toContain('An error occurred while getting version info');
           expect(actual).toContain('Package "test-package" version "99.99.99" not found');
-
-          server.close();
         });
       });
     });
@@ -486,8 +454,6 @@ describe('#NpmConnectorConfig', () => {
             })
           );
 
-          server.listen();
-
           const tool = NpmConnectorConfig.tools.GET_README as MCPToolDefinition;
           const mockContext = createMockConnectorContext();
 
@@ -497,8 +463,6 @@ describe('#NpmConnectorConfig', () => {
           expect(actual).toContain('# Test Package');
           expect(actual).toContain('This is a test package for testing purposes.');
           expect(actual).toContain('npm install test-package');
-
-          server.close();
         });
       });
 
@@ -509,8 +473,6 @@ describe('#NpmConnectorConfig', () => {
               return HttpResponse.json(mockVersionResponse);
             })
           );
-
-          server.listen();
 
           const tool = NpmConnectorConfig.tools.GET_README as MCPToolDefinition;
           const mockContext = createMockConnectorContext();
@@ -523,8 +485,6 @@ describe('#NpmConnectorConfig', () => {
           expect(actual).toContain('README for test-package@1.2.3:');
           expect(actual).toContain('# Test Package v1.2.3');
           expect(actual).toContain('This is the specific version readme.');
-
-          server.close();
         });
       });
 
@@ -540,8 +500,6 @@ describe('#NpmConnectorConfig', () => {
             })
           );
 
-          server.listen();
-
           const tool = NpmConnectorConfig.tools.GET_README as MCPToolDefinition;
           const mockContext = createMockConnectorContext();
 
@@ -549,8 +507,6 @@ describe('#NpmConnectorConfig', () => {
 
           expect(actual).toContain('[README truncated - content was too long]');
           expect(actual.length).toBeLessThan(15000);
-
-          server.close();
         });
       });
     });
@@ -567,16 +523,12 @@ describe('#NpmConnectorConfig', () => {
             })
           );
 
-          server.listen();
-
           const tool = NpmConnectorConfig.tools.GET_README as MCPToolDefinition;
           const mockContext = createMockConnectorContext();
 
           const actual = await tool.handler({ packageName: 'test-package' }, mockContext);
 
           expect(actual).toBe('No README found for package "test-package"');
-
-          server.close();
         });
       });
     });
@@ -590,8 +542,6 @@ describe('#NpmConnectorConfig', () => {
             })
           );
 
-          server.listen();
-
           const tool = NpmConnectorConfig.tools.GET_README as MCPToolDefinition;
           const mockContext = createMockConnectorContext();
 
@@ -602,8 +552,6 @@ describe('#NpmConnectorConfig', () => {
 
           expect(actual).toContain('An error occurred while getting README');
           expect(actual).toContain('Package "nonexistent-package" not found');
-
-          server.close();
         });
       });
     });

--- a/packages/mcp-connectors/src/connectors/npm.spec.ts
+++ b/packages/mcp-connectors/src/connectors/npm.spec.ts
@@ -1,0 +1,611 @@
+import type { MCPToolDefinition } from '@stackone/mcp-config-types';
+import { http, HttpResponse } from 'msw';
+import { setupServer } from 'msw/node';
+import { describe, expect, it } from 'vitest';
+import { createMockConnectorContext } from '../__mocks__/context';
+import { NpmConnectorConfig } from './npm';
+
+const mockSearchResponse = {
+  objects: [
+    {
+      package: {
+        name: 'test-package',
+        version: '1.2.3',
+        description: 'A test package for testing purposes',
+        keywords: ['test', 'npm', 'package'],
+        author: {
+          name: 'Test Author',
+          email: 'test@example.com',
+        },
+        publisher: {
+          username: 'testuser',
+          email: 'test@example.com',
+        },
+        maintainers: [
+          {
+            username: 'testuser',
+            email: 'test@example.com',
+          },
+        ],
+      },
+      score: {
+        final: 0.95,
+        detail: {
+          quality: 0.9,
+          popularity: 0.8,
+          maintenance: 0.7,
+        },
+      },
+      searchScore: 0.95,
+    },
+    {
+      package: {
+        name: 'another-package',
+        version: '2.1.0',
+        description: 'Another test package',
+        keywords: ['test'],
+        author: {
+          name: 'Another Author',
+        },
+        publisher: {
+          username: 'anotheruser',
+          email: 'another@example.com',
+        },
+        maintainers: [
+          {
+            username: 'anotheruser',
+            email: 'another@example.com',
+          },
+        ],
+      },
+      score: {
+        final: 0.87,
+        detail: {
+          quality: 0.8,
+          popularity: 0.9,
+          maintenance: 0.6,
+        },
+      },
+      searchScore: 0.87,
+    },
+  ],
+  total: 2,
+  time: '2024-01-01T00:00:00.000Z',
+};
+
+const mockPackageResponse = {
+  _id: 'test-package',
+  name: 'test-package',
+  description: 'A comprehensive test package',
+  'dist-tags': {
+    latest: '1.2.3',
+    beta: '1.3.0-beta.1',
+  },
+  versions: {
+    '1.2.3': {
+      name: 'test-package',
+      version: '1.2.3',
+      description: 'A comprehensive test package',
+      main: 'index.js',
+      scripts: {
+        test: 'jest',
+        build: 'tsc',
+      },
+      dependencies: {
+        lodash: '^4.17.21',
+        axios: '^0.27.2',
+      },
+      devDependencies: {
+        jest: '^28.0.0',
+        typescript: '^4.7.0',
+      },
+      keywords: ['test', 'npm'],
+      author: {
+        name: 'Test Author',
+        email: 'test@example.com',
+      },
+      license: 'MIT',
+      repository: {
+        type: 'git',
+        url: 'https://github.com/test/test-package.git',
+      },
+      homepage: 'https://test-package.com',
+      readme:
+        "# Test Package\n\nThis is a test package for testing purposes.\n\n## Installation\n\n```bash\nnpm install test-package\n```\n\n## Usage\n\n```javascript\nconst testPackage = require('test-package');\n```",
+    },
+    '1.2.2': {
+      name: 'test-package',
+      version: '1.2.2',
+      description: 'A comprehensive test package',
+    },
+  },
+  time: {
+    created: '2024-01-01T00:00:00.000Z',
+    modified: '2024-01-02T00:00:00.000Z',
+    '1.2.3': '2024-01-02T00:00:00.000Z',
+    '1.2.2': '2024-01-01T12:00:00.000Z',
+  },
+  maintainers: [
+    {
+      name: 'testuser',
+      email: 'test@example.com',
+    },
+  ],
+  author: {
+    name: 'Test Author',
+    email: 'test@example.com',
+  },
+  repository: {
+    type: 'git',
+    url: 'https://github.com/test/test-package.git',
+  },
+  homepage: 'https://test-package.com',
+  license: 'MIT',
+  keywords: ['test', 'npm'],
+  readme:
+    "# Test Package\n\nThis is a test package for testing purposes.\n\n## Installation\n\n```bash\nnpm install test-package\n```\n\n## Usage\n\n```javascript\nconst testPackage = require('test-package');\n```",
+};
+
+const mockVersionResponse = {
+  name: 'test-package',
+  version: '1.2.3',
+  description: 'A comprehensive test package',
+  main: 'index.js',
+  scripts: {
+    test: 'jest',
+    build: 'tsc',
+  },
+  dependencies: {
+    lodash: '^4.17.21',
+    axios: '^0.27.2',
+  },
+  devDependencies: {
+    jest: '^28.0.0',
+    typescript: '^4.7.0',
+  },
+  peerDependencies: {
+    react: '>=16.0.0',
+  },
+  keywords: ['test', 'npm'],
+  author: {
+    name: 'Test Author',
+    email: 'test@example.com',
+  },
+  license: 'MIT',
+  repository: {
+    type: 'git',
+    url: 'https://github.com/test/test-package.git',
+  },
+  homepage: 'https://test-package.com',
+  bugs: {
+    url: 'https://github.com/test/test-package/issues',
+  },
+  readme: '# Test Package v1.2.3\n\nThis is the specific version readme.',
+};
+
+const server = setupServer();
+
+describe('#NpmConnectorConfig', () => {
+  describe('.SEARCH_PACKAGES', () => {
+    describe('when search is successful', () => {
+      describe('and packages are found', () => {
+        it('returns formatted search results', async () => {
+          server.use(
+            http.get('https://registry.npmjs.org/-/v1/search', ({ request }) => {
+              const url = new URL(request.url);
+              const query = url.searchParams.get('text');
+              const size = url.searchParams.get('size');
+
+              expect(query).toBe('test');
+              expect(size).toBe('20');
+
+              return HttpResponse.json(mockSearchResponse);
+            })
+          );
+
+          server.listen();
+
+          const tool = NpmConnectorConfig.tools.SEARCH_PACKAGES as MCPToolDefinition;
+          const mockContext = createMockConnectorContext();
+
+          const actual = await tool.handler({ query: 'test' }, mockContext);
+
+          expect(actual).toContain('Found 2 npm packages:');
+          expect(actual).toContain('1. test-package@1.2.3');
+          expect(actual).toContain('Description: A test package for testing purposes');
+          expect(actual).toContain('Keywords: test, npm, package');
+          expect(actual).toContain('Author: Test Author <test@example.com>');
+          expect(actual).toContain('Score: 0.95');
+          expect(actual).toContain('https://npmjs.com/package/test-package');
+          expect(actual).toContain('2. another-package@2.1.0');
+
+          server.close();
+        });
+      });
+
+      describe('and custom size is specified', () => {
+        it('uses the specified size parameter', async () => {
+          server.use(
+            http.get('https://registry.npmjs.org/-/v1/search', ({ request }) => {
+              const url = new URL(request.url);
+              const size = url.searchParams.get('size');
+
+              expect(size).toBe('5');
+
+              return HttpResponse.json({ ...mockSearchResponse, objects: [] });
+            })
+          );
+
+          server.listen();
+
+          const tool = NpmConnectorConfig.tools.SEARCH_PACKAGES as MCPToolDefinition;
+          const mockContext = createMockConnectorContext();
+
+          await tool.handler({ query: 'test', size: 5 }, mockContext);
+
+          server.close();
+        });
+      });
+
+      describe('and no packages are found', () => {
+        it('returns no results message', async () => {
+          server.use(
+            http.get('https://registry.npmjs.org/-/v1/search', () => {
+              return HttpResponse.json({
+                objects: [],
+                total: 0,
+                time: '2024-01-01T00:00:00.000Z',
+              });
+            })
+          );
+
+          server.listen();
+
+          const tool = NpmConnectorConfig.tools.SEARCH_PACKAGES as MCPToolDefinition;
+          const mockContext = createMockConnectorContext();
+
+          const actual = await tool.handler({ query: 'nonexistent' }, mockContext);
+
+          expect(actual).toBe('No packages found for your search query.');
+
+          server.close();
+        });
+      });
+    });
+
+    describe('when search fails', () => {
+      describe('and API returns error', () => {
+        it('returns error message', async () => {
+          server.use(
+            http.get('https://registry.npmjs.org/-/v1/search', () => {
+              return HttpResponse.json(
+                { error: 'Internal server error' },
+                { status: 500 }
+              );
+            })
+          );
+
+          server.listen();
+
+          const tool = NpmConnectorConfig.tools.SEARCH_PACKAGES as MCPToolDefinition;
+          const mockContext = createMockConnectorContext();
+
+          const actual = await tool.handler({ query: 'test' }, mockContext);
+
+          expect(actual).toContain('An error occurred while searching packages');
+          expect(actual).toContain('HTTP error! Status: 500');
+
+          server.close();
+        });
+      });
+    });
+  });
+
+  describe('.GET_PACKAGE_INFO', () => {
+    describe('when package exists', () => {
+      describe('and request is successful', () => {
+        it('returns formatted package information', async () => {
+          server.use(
+            http.get('https://registry.npmjs.org/test-package', () => {
+              return HttpResponse.json(mockPackageResponse);
+            })
+          );
+
+          server.listen();
+
+          const tool = NpmConnectorConfig.tools.GET_PACKAGE_INFO as MCPToolDefinition;
+          const mockContext = createMockConnectorContext();
+
+          const actual = await tool.handler({ packageName: 'test-package' }, mockContext);
+
+          expect(actual).toContain('Package Information for test-package:');
+          expect(actual).toContain('Latest Version: 1.2.3');
+          expect(actual).toContain('Description: A comprehensive test package');
+          expect(actual).toContain('Keywords: test, npm');
+          expect(actual).toContain('Author: Test Author <test@example.com>');
+          expect(actual).toContain('License: MIT');
+          expect(actual).toContain('Homepage: https://test-package.com');
+          expect(actual).toContain(
+            'Repository: https://github.com/test/test-package.git'
+          );
+          expect(actual).toContain('Maintainers: testuser');
+          expect(actual).toContain('https://npmjs.com/package/test-package');
+
+          server.close();
+        });
+      });
+
+      describe('and package name contains special characters', () => {
+        it('properly encodes the package name', async () => {
+          server.use(
+            http.get('https://registry.npmjs.org/@types%2Fnode', () => {
+              return HttpResponse.json({
+                ...mockPackageResponse,
+                name: '@types/node',
+                _id: '@types/node',
+              });
+            })
+          );
+
+          server.listen();
+
+          const tool = NpmConnectorConfig.tools.GET_PACKAGE_INFO as MCPToolDefinition;
+          const mockContext = createMockConnectorContext();
+
+          const actual = await tool.handler({ packageName: '@types/node' }, mockContext);
+
+          expect(actual).toContain('Package Information for @types/node:');
+
+          server.close();
+        });
+      });
+    });
+
+    describe('when package does not exist', () => {
+      describe('and API returns 404', () => {
+        it('returns package not found error', async () => {
+          server.use(
+            http.get('https://registry.npmjs.org/nonexistent-package', () => {
+              return HttpResponse.json({ error: 'Not found' }, { status: 404 });
+            })
+          );
+
+          server.listen();
+
+          const tool = NpmConnectorConfig.tools.GET_PACKAGE_INFO as MCPToolDefinition;
+          const mockContext = createMockConnectorContext();
+
+          const actual = await tool.handler(
+            { packageName: 'nonexistent-package' },
+            mockContext
+          );
+
+          expect(actual).toContain('An error occurred while getting package info');
+          expect(actual).toContain('Package "nonexistent-package" not found');
+
+          server.close();
+        });
+      });
+    });
+  });
+
+  describe('.GET_VERSION_INFO', () => {
+    describe('when version exists', () => {
+      describe('and specific version is requested', () => {
+        it('returns formatted version information', async () => {
+          server.use(
+            http.get('https://registry.npmjs.org/test-package/1.2.3', () => {
+              return HttpResponse.json(mockVersionResponse);
+            })
+          );
+
+          server.listen();
+
+          const tool = NpmConnectorConfig.tools.GET_VERSION_INFO as MCPToolDefinition;
+          const mockContext = createMockConnectorContext();
+
+          const actual = await tool.handler(
+            { packageName: 'test-package', version: '1.2.3' },
+            mockContext
+          );
+
+          expect(actual).toContain('Version Information for test-package@1.2.3:');
+          expect(actual).toContain('Description: A comprehensive test package');
+          expect(actual).toContain('Main: index.js');
+          expect(actual).toContain('Scripts:');
+          expect(actual).toContain('test: jest');
+          expect(actual).toContain('build: tsc');
+          expect(actual).toContain('Dependencies: 2 packages');
+          expect(actual).toContain('lodash: ^4.17.21');
+          expect(actual).toContain('axios: ^0.27.2');
+          expect(actual).toContain('Dev Dependencies: 2 packages');
+          expect(actual).toContain('Peer Dependencies: 1 packages');
+          expect(actual).toContain('https://npmjs.com/package/test-package/v/1.2.3');
+
+          server.close();
+        });
+      });
+
+      describe('and latest version is requested', () => {
+        it('uses latest as default version', async () => {
+          server.use(
+            http.get('https://registry.npmjs.org/test-package/latest', () => {
+              return HttpResponse.json(mockVersionResponse);
+            })
+          );
+
+          server.listen();
+
+          const tool = NpmConnectorConfig.tools.GET_VERSION_INFO as MCPToolDefinition;
+          const mockContext = createMockConnectorContext();
+
+          const actual = await tool.handler({ packageName: 'test-package' }, mockContext);
+
+          expect(actual).toContain('Version Information for test-package@1.2.3:');
+
+          server.close();
+        });
+      });
+    });
+
+    describe('when version does not exist', () => {
+      describe('and API returns 404', () => {
+        it('returns version not found error', async () => {
+          server.use(
+            http.get('https://registry.npmjs.org/test-package/99.99.99', () => {
+              return HttpResponse.json({ error: 'Not found' }, { status: 404 });
+            })
+          );
+
+          server.listen();
+
+          const tool = NpmConnectorConfig.tools.GET_VERSION_INFO as MCPToolDefinition;
+          const mockContext = createMockConnectorContext();
+
+          const actual = await tool.handler(
+            { packageName: 'test-package', version: '99.99.99' },
+            mockContext
+          );
+
+          expect(actual).toContain('An error occurred while getting version info');
+          expect(actual).toContain('Package "test-package" version "99.99.99" not found');
+
+          server.close();
+        });
+      });
+    });
+  });
+
+  describe('.GET_README', () => {
+    describe('when package has README', () => {
+      describe('and no version is specified', () => {
+        it('returns README from package info', async () => {
+          server.use(
+            http.get('https://registry.npmjs.org/test-package', () => {
+              return HttpResponse.json(mockPackageResponse);
+            })
+          );
+
+          server.listen();
+
+          const tool = NpmConnectorConfig.tools.GET_README as MCPToolDefinition;
+          const mockContext = createMockConnectorContext();
+
+          const actual = await tool.handler({ packageName: 'test-package' }, mockContext);
+
+          expect(actual).toContain('README for test-package:');
+          expect(actual).toContain('# Test Package');
+          expect(actual).toContain('This is a test package for testing purposes.');
+          expect(actual).toContain('npm install test-package');
+
+          server.close();
+        });
+      });
+
+      describe('and specific version is specified', () => {
+        it('returns README from version info', async () => {
+          server.use(
+            http.get('https://registry.npmjs.org/test-package/1.2.3', () => {
+              return HttpResponse.json(mockVersionResponse);
+            })
+          );
+
+          server.listen();
+
+          const tool = NpmConnectorConfig.tools.GET_README as MCPToolDefinition;
+          const mockContext = createMockConnectorContext();
+
+          const actual = await tool.handler(
+            { packageName: 'test-package', version: '1.2.3' },
+            mockContext
+          );
+
+          expect(actual).toContain('README for test-package@1.2.3:');
+          expect(actual).toContain('# Test Package v1.2.3');
+          expect(actual).toContain('This is the specific version readme.');
+
+          server.close();
+        });
+      });
+
+      describe('and README is very long', () => {
+        it('truncates the README content', async () => {
+          const longReadme = 'A'.repeat(15000);
+          server.use(
+            http.get('https://registry.npmjs.org/test-package', () => {
+              return HttpResponse.json({
+                ...mockPackageResponse,
+                readme: longReadme,
+              });
+            })
+          );
+
+          server.listen();
+
+          const tool = NpmConnectorConfig.tools.GET_README as MCPToolDefinition;
+          const mockContext = createMockConnectorContext();
+
+          const actual = await tool.handler({ packageName: 'test-package' }, mockContext);
+
+          expect(actual).toContain('[README truncated - content was too long]');
+          expect(actual.length).toBeLessThan(15000);
+
+          server.close();
+        });
+      });
+    });
+
+    describe('when package has no README', () => {
+      describe('and package exists', () => {
+        it('returns no README found message', async () => {
+          server.use(
+            http.get('https://registry.npmjs.org/test-package', () => {
+              return HttpResponse.json({
+                ...mockPackageResponse,
+                readme: undefined,
+              });
+            })
+          );
+
+          server.listen();
+
+          const tool = NpmConnectorConfig.tools.GET_README as MCPToolDefinition;
+          const mockContext = createMockConnectorContext();
+
+          const actual = await tool.handler({ packageName: 'test-package' }, mockContext);
+
+          expect(actual).toBe('No README found for package "test-package"');
+
+          server.close();
+        });
+      });
+    });
+
+    describe('when package does not exist', () => {
+      describe('and API returns 404', () => {
+        it('returns error message', async () => {
+          server.use(
+            http.get('https://registry.npmjs.org/nonexistent-package', () => {
+              return HttpResponse.json({ error: 'Not found' }, { status: 404 });
+            })
+          );
+
+          server.listen();
+
+          const tool = NpmConnectorConfig.tools.GET_README as MCPToolDefinition;
+          const mockContext = createMockConnectorContext();
+
+          const actual = await tool.handler(
+            { packageName: 'nonexistent-package' },
+            mockContext
+          );
+
+          expect(actual).toContain('An error occurred while getting README');
+          expect(actual).toContain('Package "nonexistent-package" not found');
+
+          server.close();
+        });
+      });
+    });
+  });
+});

--- a/packages/mcp-connectors/src/connectors/npm.ts
+++ b/packages/mcp-connectors/src/connectors/npm.ts
@@ -106,6 +106,7 @@ interface NpmPackageResponse {
 
 const REGISTRY_BASE_URL = 'https://registry.npmjs.org';
 const SEARCH_BASE_URL = 'https://registry.npmjs.org/-/v1/search';
+const MAX_README_LENGTH = 10000;
 
 const searchPackages = async (query: string, size = 20): Promise<NpmSearchResponse> => {
   console.info(`Searching npm packages for: ${query}`);
@@ -444,8 +445,8 @@ export const NpmConnectorConfig = mcpConnectorConfig({
           }
 
           // Truncate if too long for better readability
-          if (readmeContent.length > 10000) {
-            readmeContent = `${readmeContent.substring(0, 10000)}\n\n[README truncated - content was too long]`;
+          if (readmeContent.length > MAX_README_LENGTH) {
+            readmeContent = `${readmeContent.substring(0, MAX_README_LENGTH)}\n\n[README truncated - content was too long]`;
           }
 
           return `README for ${args.packageName}${args.version ? `@${args.version}` : ''}:\n\n${readmeContent}`;

--- a/packages/mcp-connectors/src/connectors/npm.ts
+++ b/packages/mcp-connectors/src/connectors/npm.ts
@@ -1,6 +1,11 @@
 import { mcpConnectorConfig } from '@stackone/mcp-config-types';
 import { z } from 'zod';
 
+// Helper function to pluralize package count
+const pluralize = (count: number, singular: string, plural = `${singular}s`) => {
+  return count === 1 ? `${count} ${singular}` : `${count} ${plural}`;
+};
+
 interface NpmSearchResult {
   package: {
     name: string;
@@ -288,13 +293,14 @@ const formatVersionInfo = (versionData: NpmVersionData): string => {
   }
 
   if (versionData.dependencies && Object.keys(versionData.dependencies).length > 0) {
-    output.push(`Dependencies: ${Object.keys(versionData.dependencies).length} packages`);
+    const depCount = Object.keys(versionData.dependencies).length;
+    output.push(`Dependencies: ${pluralize(depCount, 'package')}`);
     const depList = Object.entries(versionData.dependencies).slice(0, 5);
     for (const [dep, version] of depList) {
       output.push(`  ${dep}: ${version}`);
     }
-    if (Object.keys(versionData.dependencies).length > 5) {
-      output.push(`  ... and ${Object.keys(versionData.dependencies).length - 5} more`);
+    if (depCount > 5) {
+      output.push(`  ... and ${depCount - 5} more`);
     }
   }
 
@@ -302,18 +308,16 @@ const formatVersionInfo = (versionData: NpmVersionData): string => {
     versionData.devDependencies &&
     Object.keys(versionData.devDependencies).length > 0
   ) {
-    output.push(
-      `Dev Dependencies: ${Object.keys(versionData.devDependencies).length} packages`
-    );
+    const devDepCount = Object.keys(versionData.devDependencies).length;
+    output.push(`Dev Dependencies: ${pluralize(devDepCount, 'package')}`);
   }
 
   if (
     versionData.peerDependencies &&
     Object.keys(versionData.peerDependencies).length > 0
   ) {
-    output.push(
-      `Peer Dependencies: ${Object.keys(versionData.peerDependencies).length} packages`
-    );
+    const peerDepCount = Object.keys(versionData.peerDependencies).length;
+    output.push(`Peer Dependencies: ${pluralize(peerDepCount, 'package')}`);
   }
 
   if (versionData.keywords && versionData.keywords.length > 0) {

--- a/packages/mcp-connectors/src/connectors/npm.ts
+++ b/packages/mcp-connectors/src/connectors/npm.ts
@@ -1,0 +1,459 @@
+import { mcpConnectorConfig } from '@stackone/mcp-config-types';
+import { z } from 'zod';
+
+interface NpmSearchResult {
+  package: {
+    name: string;
+    version: string;
+    description?: string;
+    keywords?: string[];
+    author?: {
+      name: string;
+      email?: string;
+    };
+    publisher: {
+      username: string;
+      email: string;
+    };
+    maintainers: Array<{
+      username: string;
+      email: string;
+    }>;
+  };
+  score: {
+    final: number;
+    detail: {
+      quality: number;
+      popularity: number;
+      maintenance: number;
+    };
+  };
+  searchScore: number;
+}
+
+interface NpmSearchResponse {
+  objects: NpmSearchResult[];
+  total: number;
+  time: string;
+}
+
+interface NpmVersionData {
+  name: string;
+  version: string;
+  description?: string;
+  main?: string;
+  scripts?: Record<string, string>;
+  dependencies?: Record<string, string>;
+  devDependencies?: Record<string, string>;
+  peerDependencies?: Record<string, string>;
+  keywords?: string[];
+  author?:
+    | {
+        name: string;
+        email?: string;
+      }
+    | string;
+  license?: string;
+  repository?: {
+    type: string;
+    url: string;
+  };
+  homepage?: string;
+  bugs?: {
+    url?: string;
+    email?: string;
+  };
+  readme?: string;
+  maintainers?: Array<{
+    name: string;
+    email?: string;
+  }>;
+}
+
+interface NpmPackageResponse {
+  _id: string;
+  name: string;
+  description?: string;
+  'dist-tags': {
+    latest: string;
+    [tag: string]: string;
+  };
+  versions: Record<string, NpmVersionData>;
+  time: Record<string, string>;
+  maintainers: Array<{
+    name: string;
+    email?: string;
+  }>;
+  author?:
+    | {
+        name: string;
+        email?: string;
+      }
+    | string;
+  repository?: {
+    type: string;
+    url: string;
+  };
+  homepage?: string;
+  bugs?: {
+    url?: string;
+    email?: string;
+  };
+  license?: string;
+  keywords?: string[];
+  readme?: string;
+}
+
+const REGISTRY_BASE_URL = 'https://registry.npmjs.org';
+const SEARCH_BASE_URL = 'https://registry.npmjs.org/-/v1/search';
+
+const searchPackages = async (query: string, size = 20): Promise<NpmSearchResponse> => {
+  console.info(`Searching npm packages for: ${query}`);
+
+  const searchUrl = new URL(SEARCH_BASE_URL);
+  searchUrl.searchParams.set('text', query);
+  searchUrl.searchParams.set('size', size.toString());
+
+  try {
+    const response = await fetch(searchUrl.toString());
+
+    if (!response.ok) {
+      throw new Error(`HTTP error! Status: ${response.status}`);
+    }
+
+    const data = (await response.json()) as NpmSearchResponse;
+    console.info(`Successfully found ${data.objects.length} packages`);
+    return data;
+  } catch (error) {
+    console.error('Search request failed:', error);
+    throw error;
+  }
+};
+
+const getPackageInfo = async (packageName: string): Promise<NpmPackageResponse> => {
+  console.info(`Getting package info for: ${packageName}`);
+
+  const encodedPackageName = encodeURIComponent(packageName);
+  const url = `${REGISTRY_BASE_URL}/${encodedPackageName}`;
+
+  try {
+    const response = await fetch(url);
+
+    if (!response.ok) {
+      if (response.status === 404) {
+        throw new Error(`Package "${packageName}" not found`);
+      }
+      throw new Error(`HTTP error! Status: ${response.status}`);
+    }
+
+    const data = (await response.json()) as NpmPackageResponse;
+    console.info(`Successfully retrieved info for package: ${packageName}`);
+    return data;
+  } catch (error) {
+    console.error('Get package info request failed:', error);
+    throw error;
+  }
+};
+
+const getPackageVersion = async (
+  packageName: string,
+  version = 'latest'
+): Promise<NpmVersionData> => {
+  console.info(`Getting package version info for: ${packageName}@${version}`);
+
+  const encodedPackageName = encodeURIComponent(packageName);
+  const url = `${REGISTRY_BASE_URL}/${encodedPackageName}/${version}`;
+
+  try {
+    const response = await fetch(url);
+
+    if (!response.ok) {
+      if (response.status === 404) {
+        throw new Error(`Package "${packageName}" version "${version}" not found`);
+      }
+      throw new Error(`HTTP error! Status: ${response.status}`);
+    }
+
+    const data = (await response.json()) as NpmVersionData;
+    console.info(`Successfully retrieved version info for: ${packageName}@${version}`);
+    return data;
+  } catch (error) {
+    console.error('Get package version request failed:', error);
+    throw error;
+  }
+};
+
+const formatSearchResults = (searchResponse: NpmSearchResponse): string => {
+  if (searchResponse.objects.length === 0) {
+    return 'No packages found for your search query.';
+  }
+
+  const output = [`Found ${searchResponse.objects.length} npm packages:\n`];
+
+  for (let i = 0; i < searchResponse.objects.length; i++) {
+    const result = searchResponse.objects[i];
+    const pkg = result.package;
+
+    output.push(`${i + 1}. ${pkg.name}@${pkg.version}`);
+    if (pkg.description) {
+      output.push(`   Description: ${pkg.description}`);
+    }
+    if (pkg.keywords && pkg.keywords.length > 0) {
+      output.push(`   Keywords: ${pkg.keywords.join(', ')}`);
+    }
+    if (pkg.author && typeof pkg.author === 'object') {
+      output.push(
+        `   Author: ${pkg.author.name}${pkg.author.email ? ` <${pkg.author.email}>` : ''}`
+      );
+    }
+    output.push(
+      `   Score: ${result.score.final.toFixed(2)} (Quality: ${result.score.detail.quality.toFixed(2)}, Popularity: ${result.score.detail.popularity.toFixed(2)}, Maintenance: ${result.score.detail.maintenance.toFixed(2)})`
+    );
+    output.push(`   NPM: https://npmjs.com/package/${pkg.name}`);
+    output.push(''); // Empty line between results
+  }
+
+  return output.join('\n');
+};
+
+const formatPackageInfo = (packageData: NpmPackageResponse): string => {
+  const output = [`Package Information for ${packageData.name}:\n`];
+
+  output.push(`Latest Version: ${packageData['dist-tags'].latest}`);
+
+  if (packageData.description) {
+    output.push(`Description: ${packageData.description}`);
+  }
+
+  if (packageData.keywords && packageData.keywords.length > 0) {
+    output.push(`Keywords: ${packageData.keywords.join(', ')}`);
+  }
+
+  if (packageData.author) {
+    if (typeof packageData.author === 'string') {
+      output.push(`Author: ${packageData.author}`);
+    } else {
+      output.push(
+        `Author: ${packageData.author.name}${packageData.author.email ? ` <${packageData.author.email}>` : ''}`
+      );
+    }
+  }
+
+  if (packageData.license) {
+    output.push(`License: ${packageData.license}`);
+  }
+
+  if (packageData.homepage) {
+    output.push(`Homepage: ${packageData.homepage}`);
+  }
+
+  if (packageData.repository) {
+    output.push(`Repository: ${packageData.repository.url}`);
+  }
+
+  if (packageData.maintainers && packageData.maintainers.length > 0) {
+    output.push(`Maintainers: ${packageData.maintainers.map((m) => m.name).join(', ')}`);
+  }
+
+  // Available versions (show latest 10)
+  const versions = Object.keys(packageData.versions).reverse().slice(0, 10);
+  if (versions.length > 0) {
+    output.push(`Recent Versions: ${versions.join(', ')}`);
+  }
+
+  output.push(`NPM: https://npmjs.com/package/${packageData.name}`);
+
+  return output.join('\n');
+};
+
+const formatVersionInfo = (versionData: NpmVersionData): string => {
+  const output = [
+    `Version Information for ${versionData.name}@${versionData.version}:\n`,
+  ];
+
+  if (versionData.description) {
+    output.push(`Description: ${versionData.description}`);
+  }
+
+  if (versionData.main) {
+    output.push(`Main: ${versionData.main}`);
+  }
+
+  if (versionData.scripts && Object.keys(versionData.scripts).length > 0) {
+    output.push('Scripts:');
+    for (const [script, command] of Object.entries(versionData.scripts)) {
+      output.push(`  ${script}: ${command}`);
+    }
+  }
+
+  if (versionData.dependencies && Object.keys(versionData.dependencies).length > 0) {
+    output.push(`Dependencies: ${Object.keys(versionData.dependencies).length} packages`);
+    const depList = Object.entries(versionData.dependencies).slice(0, 5);
+    for (const [dep, version] of depList) {
+      output.push(`  ${dep}: ${version}`);
+    }
+    if (Object.keys(versionData.dependencies).length > 5) {
+      output.push(`  ... and ${Object.keys(versionData.dependencies).length - 5} more`);
+    }
+  }
+
+  if (
+    versionData.devDependencies &&
+    Object.keys(versionData.devDependencies).length > 0
+  ) {
+    output.push(
+      `Dev Dependencies: ${Object.keys(versionData.devDependencies).length} packages`
+    );
+  }
+
+  if (
+    versionData.peerDependencies &&
+    Object.keys(versionData.peerDependencies).length > 0
+  ) {
+    output.push(
+      `Peer Dependencies: ${Object.keys(versionData.peerDependencies).length} packages`
+    );
+  }
+
+  if (versionData.keywords && versionData.keywords.length > 0) {
+    output.push(`Keywords: ${versionData.keywords.join(', ')}`);
+  }
+
+  if (versionData.license) {
+    output.push(`License: ${versionData.license}`);
+  }
+
+  if (versionData.homepage) {
+    output.push(`Homepage: ${versionData.homepage}`);
+  }
+
+  if (versionData.repository) {
+    output.push(`Repository: ${versionData.repository.url}`);
+  }
+
+  output.push(
+    `NPM: https://npmjs.com/package/${versionData.name}/v/${versionData.version}`
+  );
+
+  return output.join('\n');
+};
+
+export const NpmConnectorConfig = mcpConnectorConfig({
+  name: 'npm',
+  key: 'npm',
+  logo: 'https://stackone-logos.com/api/npm/filled/svg',
+  version: '1.0.0',
+  credentials: z.object({}),
+  setup: z.object({}),
+  examplePrompt:
+    'Search for "typescript" packages, then get detailed information about the most popular TypeScript package and its latest version.',
+  tools: (tool) => ({
+    SEARCH_PACKAGES: tool({
+      name: 'search_packages',
+      description: 'Search npm packages by name, description, keywords, or author',
+      schema: z.object({
+        query: z
+          .string()
+          .describe('The search query string (package name, keywords, author, etc.)'),
+        size: z
+          .number()
+          .min(1)
+          .max(250)
+          .default(20)
+          .describe('Maximum number of results to return (1-250, default 20)'),
+      }),
+      handler: async (args, _context) => {
+        try {
+          const results = await searchPackages(args.query, args.size);
+          return formatSearchResults(results);
+        } catch (error) {
+          console.error('Error during package search:', error);
+          return `An error occurred while searching packages: ${error instanceof Error ? error.message : String(error)}`;
+        }
+      },
+    }),
+    GET_PACKAGE_INFO: tool({
+      name: 'get_package_info',
+      description:
+        'Get detailed information about a specific npm package including all versions and metadata',
+      schema: z.object({
+        packageName: z
+          .string()
+          .describe('The exact package name (e.g., "react", "@types/node")'),
+      }),
+      handler: async (args, _context) => {
+        try {
+          const packageData = await getPackageInfo(args.packageName);
+          return formatPackageInfo(packageData);
+        } catch (error) {
+          console.error('Error getting package info:', error);
+          return `An error occurred while getting package info: ${error instanceof Error ? error.message : String(error)}`;
+        }
+      },
+    }),
+    GET_VERSION_INFO: tool({
+      name: 'get_version_info',
+      description: 'Get detailed information about a specific version of an npm package',
+      schema: z.object({
+        packageName: z
+          .string()
+          .describe('The exact package name (e.g., "react", "@types/node")'),
+        version: z
+          .string()
+          .default('latest')
+          .describe(
+            'The version to get info for (default: "latest", can be specific version like "1.2.3")'
+          ),
+      }),
+      handler: async (args, _context) => {
+        try {
+          const versionData = await getPackageVersion(args.packageName, args.version);
+          return formatVersionInfo(versionData);
+        } catch (error) {
+          console.error('Error getting version info:', error);
+          return `An error occurred while getting version info: ${error instanceof Error ? error.message : String(error)}`;
+        }
+      },
+    }),
+    GET_README: tool({
+      name: 'get_readme',
+      description: 'Get the README content for a specific npm package',
+      schema: z.object({
+        packageName: z
+          .string()
+          .describe('The exact package name (e.g., "react", "@types/node")'),
+        version: z
+          .string()
+          .optional()
+          .describe('Optional specific version (if not provided, uses latest version)'),
+      }),
+      handler: async (args, _context) => {
+        try {
+          let readmeContent: string | undefined;
+
+          if (args.version) {
+            const versionData = await getPackageVersion(args.packageName, args.version);
+            readmeContent = versionData.readme;
+          } else {
+            const packageData = await getPackageInfo(args.packageName);
+            readmeContent = packageData.readme;
+          }
+
+          if (!readmeContent) {
+            return `No README found for package "${args.packageName}"${args.version ? `@${args.version}` : ''}`;
+          }
+
+          // Truncate if too long for better readability
+          if (readmeContent.length > 10000) {
+            readmeContent = `${readmeContent.substring(0, 10000)}\n\n[README truncated - content was too long]`;
+          }
+
+          return `README for ${args.packageName}${args.version ? `@${args.version}` : ''}:\n\n${readmeContent}`;
+        } catch (error) {
+          console.error('Error getting README:', error);
+          return `An error occurred while getting README: ${error instanceof Error ? error.message : String(error)}`;
+        }
+      },
+    }),
+  }),
+});

--- a/packages/mcp-connectors/src/index.ts
+++ b/packages/mcp-connectors/src/index.ts
@@ -22,6 +22,7 @@ import { LangsmithConnectorConfig } from './connectors/langsmith';
 import { LinearConnectorConfig } from './connectors/linear';
 import { LinkedInConnectorConfig } from './connectors/linkedin';
 import { NotionConnectorConfig } from './connectors/notion';
+import { NpmConnectorConfig } from './connectors/npm';
 import { OnePasswordConnectorConfig } from './connectors/onepassword';
 import { ParallelConnectorConfig } from './connectors/parallel';
 import { PerplexityConnectorConfig } from './connectors/perplexity';
@@ -65,6 +66,7 @@ export const Connectors: readonly MCPConnectorConfig[] = [
   LinkedInConnectorConfig,
   LogfireConnectorConfig,
   NotionConnectorConfig,
+  NpmConnectorConfig,
   OnePasswordConnectorConfig,
   ParallelConnectorConfig,
   PerplexityConnectorConfig,
@@ -106,6 +108,7 @@ export {
   LinkedInConnectorConfig,
   LogfireConnectorConfig,
   NotionConnectorConfig,
+  NpmConnectorConfig,
   OnePasswordConnectorConfig,
   ParallelConnectorConfig,
   PerplexityConnectorConfig,


### PR DESCRIPTION
Implements npm connector as requested in issue #73

## Features
- Search npm packages by name, description, keywords, or author
- Get detailed package information including versions and metadata
- Retrieve specific version information with dependencies
- Get README content for packages
- Comprehensive test coverage for all functionality
- Uses npm registry API endpoints for real-time data

Fixes #73

🤖 Generated with [Claude Code](https://claude.ai/code)
    
<!-- This is an auto-generated description by cubic. -->
---

## Summary by cubic
Add an npm connector to search packages and fetch package info, version details, and READMEs. Registers the connector in the MCP list and fulfills the requirements from issue #73.

- New Features
  - Adds npm connector (key: npm) with tools: search_packages, get_package_info, get_version_info, get_readme.
  - Search by text with size 1–250; returns formatted results with scores and npm links.
  - Package info includes dist-tags, recent versions, author/maintainers, repo, homepage, license; supports scoped names.
  - Version info shows scripts and dependency summaries; defaults to latest; includes direct version link.
  - README retrieval for a package or a specific version; truncates very long content.
  - Uses public npm registry APIs; no credentials required. Connector is registered and exported. Comprehensive tests cover success and error paths.

<!-- End of auto-generated description by cubic. -->

