### PR TITLE
fixi: export ts file so that we don't need to build it everytime

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,61 +1,70 @@
 {
-    "name": "mcp-connectors",
-    "version": "0.1.0",
-    "private": true,
-    "description": "monorepo for mcp connectors for disco.dev",
-    "workspaces": ["packages/*", "apps/*"],
-    "module": "./dist/index.js",
-    "main": "./dist/index.js",
-    "types": "./dist/index.d.ts",
-    "exports": {
-        ".": "./dist/index.js",
-        "./package.json": "./package.json"
-    },
-    "type": "module",
-    "files": ["dist", "README.md", "LICENSE"],
-    "scripts": {
-        "start": "tsx --watch ./scripts/start-server.ts",
-        "start:test": "tsx --watch ./scripts/test-server.ts",
-        "prepare": "husky",
-        "build": "turbo build",
-        "test": "turbo test",
-        "check": "biome check .",
-        "check:fix": "biome check --fix .",
-        "typecheck": "turbo typecheck"
-    },
-    "dependencies": {
-        "@stackone/mcp-config-types": "workspace:*",
-        "@stackone/mcp-connectors": "workspace:*"
-    },
-    "devDependencies": {
-        "@biomejs/biome": "^1.5.3",
-        "@hono/mcp": "^0.1.1",
-        "@hono/node-server": "^0.6.0",
-        "@modelcontextprotocol/sdk": "^1.17.2",
-        "@types/node": "^22.13.5",
-        "@typescript/native-preview": "^7.0.0-dev.20250815.1",
-        "hono": "^4.9.0",
-        "husky": "^9.1.7",
-        "lint-staged": "^15.2.0",
-        "msw": "^2.10.4",
-        "publint": "^0.3.12",
-        "tsdown": "^0.14.0",
-        "turbo": "latest",
-        "typescript": "^5.9.0",
-        "unplugin-unused": "^0.5.1",
-        "vitest": "^3.2.4",
-        "vitest-mock-extended": "^3.1.0"
-    },
-    "repository": {
-        "type": "git",
-        "url": "git+https://github.com/StackOneHQ/mcp-connectors.git"
-    },
-    "author": "StackOne",
-    "license": "Apache-2.0",
-    "bugs": "https://github.com/StackOneHQ/mcp-connectors/issues",
-    "homepage": "https://github.com/StackOneHQ/mcp-connectors#readme",
-    "lint-staged": {
-        "*": ["biome check --fix --no-errors-on-unmatched"]
-    },
-    "packageManager": "bun@1.2.18"
+  "name": "mcp-connectors",
+  "version": "0.1.0",
+  "private": true,
+  "description": "monorepo for mcp connectors for disco.dev",
+  "workspaces": [
+    "packages/*",
+    "apps/*"
+  ],
+  "module": "./dist/index.js",
+  "main": "./dist/index.js",
+  "types": "./dist/index.d.ts",
+  "exports": {
+    ".": "./dist/index.js",
+    "./package.json": "./package.json"
+  },
+  "type": "module",
+  "files": [
+    "dist",
+    "README.md",
+    "LICENSE"
+  ],
+  "scripts": {
+    "start": "bun --dev ./scripts/start-server.ts",
+    "start:test": "bun --dev ./scripts/test-server.ts",
+    "prepare": "husky",
+    "build": "turbo build",
+    "test": "turbo test",
+    "check": "biome check .",
+    "check:fix": "biome check --fix .",
+    "typecheck": "turbo typecheck"
+  },
+  "dependencies": {
+    "@stackone/mcp-config-types": "workspace:*",
+    "@stackone/mcp-connectors": "workspace:*"
+  },
+  "devDependencies": {
+    "@biomejs/biome": "^1.5.3",
+    "@hono/mcp": "^0.1.1",
+    "@hono/node-server": "^0.6.0",
+    "@modelcontextprotocol/sdk": "^1.17.2",
+    "@types/node": "^22.13.5",
+    "@typescript/native-preview": "^7.0.0-dev.20250815.1",
+    "hono": "^4.9.0",
+    "husky": "^9.1.7",
+    "lint-staged": "^15.2.0",
+    "msw": "^2.10.4",
+    "publint": "^0.3.12",
+    "tsdown": "^0.14.0",
+    "turbo": "latest",
+    "typescript": "^5.9.0",
+    "unplugin-unused": "^0.5.1",
+    "vitest": "^3.2.4",
+    "vitest-mock-extended": "^3.1.0"
+  },
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/StackOneHQ/mcp-connectors.git"
+  },
+  "author": "StackOne",
+  "license": "Apache-2.0",
+  "bugs": "https://github.com/StackOneHQ/mcp-connectors/issues",
+  "homepage": "https://github.com/StackOneHQ/mcp-connectors#readme",
+  "lint-staged": {
+    "*": [
+      "biome check --fix --no-errors-on-unmatched"
+    ]
+  },
+  "packageManager": "bun@1.2.18"
 }


### PR DESCRIPTION

    
<!-- This is an auto-generated description by cubic. -->

## Summary by cubic
Replaced tsx with Bun for dev scripts, running servers with bun --dev. Speeds up local dev and standardizes on our existing Bun setup.

- **Refactors**
  - Updated scripts: start and start:test now use bun --dev instead of tsx --watch.

<!-- End of auto-generated description by cubic. -->

