### PR TITLE
feat: hubspot connector

### DIFF
--- a/docs/writing-connectors.md
+++ b/docs/writing-connectors.md
@@ -21,6 +21,21 @@ Rules:
 
 - capabilities should be named like `<connector name>_<tool name>` or `<connector name>_<resource name>`
 
+## Logos
+
+In general we want to use the stackone-logos.com api when we specify the logos. The format is `https://stackone-logos.com/api/<connector-key>/<logo-type>/<format>`
+
+- connector-key is the key of the connector
+- logo-type is the type of logo you want to use.
+- format is the format of the logo you want to use.
+- example: `https://stackone-logos.com/api/googledrive/filled/svg`
+- the logo type can be `filled` or `icon`
+- the format can be `svg` or `png`
+
+the connector keys are all lower case with special characters and spaces removed.
+
+Otherwise we can accept an external image url as a logo.
+
 ## Testing Requirements
 
 ### File Organization

--- a/packages/mcp-connectors/src/__mocks__/context.ts
+++ b/packages/mcp-connectors/src/__mocks__/context.ts
@@ -1,13 +1,20 @@
 import type { ConnectorContext } from '@stackone/mcp-config-types';
 import { vi } from 'vitest';
 
-export function createMockConnectorContext(): ConnectorContext {
+export interface MockContextOptions {
+  credentials?: Record<string, unknown>;
+  setup?: Record<string, unknown>;
+  data?: unknown;
+  cache?: Record<string, unknown> | null;
+}
+
+export function createMockConnectorContext(options?: MockContextOptions): ConnectorContext {
   return {
-    getCredentials: vi.fn().mockResolvedValue({}),
-    getSetup: vi.fn().mockResolvedValue({}),
-    getData: vi.fn().mockResolvedValue(undefined),
+    getCredentials: vi.fn().mockResolvedValue(options?.credentials ?? {}),
+    getSetup: vi.fn().mockResolvedValue(options?.setup ?? {}),
+    getData: vi.fn().mockResolvedValue(options?.data ?? undefined),
     setData: vi.fn().mockResolvedValue(undefined),
-    readCache: vi.fn().mockResolvedValue(null),
+    readCache: vi.fn().mockResolvedValue(options?.cache ?? null),
     writeCache: vi.fn().mockResolvedValue(undefined),
   } as ConnectorContext;
 }

--- a/packages/mcp-connectors/src/__mocks__/context.ts
+++ b/packages/mcp-connectors/src/__mocks__/context.ts
@@ -8,7 +8,9 @@ export interface MockContextOptions {
   cache?: Record<string, unknown> | null;
 }
 
-export function createMockConnectorContext(options?: MockContextOptions): ConnectorContext {
+export function createMockConnectorContext(
+  options?: MockContextOptions
+): ConnectorContext {
   return {
     getCredentials: vi.fn().mockResolvedValue(options?.credentials ?? {}),
     getSetup: vi.fn().mockResolvedValue(options?.setup ?? {}),

--- a/packages/mcp-connectors/src/connectors/hubspot.spec.ts
+++ b/packages/mcp-connectors/src/connectors/hubspot.spec.ts
@@ -1,0 +1,419 @@
+import { describe, expect, it, beforeAll, afterAll, afterEach } from 'vitest';
+import type { MCPToolDefinition } from '@stackone/mcp-config-types';
+import { createMockConnectorContext } from '../__mocks__/context';
+import { HubSpotConnectorConfig } from './hubspot';
+import { http, HttpResponse } from 'msw';
+import { setupServer } from 'msw/node';
+
+const HUBSPOT_API_BASE = 'https://api.hubapi.com';
+
+describe('#HubSpotConnector', () => {
+  const server = setupServer();
+
+  beforeAll(() => server.listen({ onUnhandledRequest: 'error' }));
+  afterAll(() => server.close());
+  afterEach(() => server.resetHandlers());
+
+  describe('.GET_CONTACTS', () => {
+    describe('when fetching contacts successfully', () => {
+      it('returns a list of contacts', async () => {
+        const mockContacts = {
+          results: [
+            {
+              id: '1',
+              properties: {
+                email: 'john@example.com',
+                firstname: 'John',
+                lastname: 'Doe',
+              },
+            },
+          ],
+          paging: {
+            next: {
+              after: '100',
+            },
+          },
+        };
+
+        server.use(
+          http.get(`${HUBSPOT_API_BASE}/crm/v3/objects/contacts`, () => {
+            return HttpResponse.json(mockContacts);
+          })
+        );
+
+        const tool = HubSpotConnectorConfig.tools.GET_CONTACTS as MCPToolDefinition;
+        const mockContext = createMockConnectorContext({
+          credentials: { apiKey: 'test-api-key' },
+        });
+
+        const actual = await tool.handler(
+          { limit: 10 },
+          mockContext
+        );
+
+        const content = JSON.parse(actual);
+        expect(content.results).toHaveLength(1);
+        expect(content.results[0].properties.email).toBe('john@example.com');
+      });
+
+      describe('and pagination is provided', () => {
+        it('includes pagination parameters', async () => {
+          const mockContacts = { results: [], paging: {} };
+          
+          let capturedUrl: URL | undefined;
+          server.use(
+            http.get(`${HUBSPOT_API_BASE}/crm/v3/objects/contacts`, ({ request }) => {
+              capturedUrl = new URL(request.url);
+              return HttpResponse.json(mockContacts);
+            })
+          );
+
+          const tool = HubSpotConnectorConfig.tools.GET_CONTACTS as MCPToolDefinition;
+          const mockContext = createMockConnectorContext({
+            credentials: { apiKey: 'test-api-key' },
+          });
+
+          await tool.handler(
+            { limit: 20, after: 'cursor123' },
+            mockContext
+          );
+
+          expect(capturedUrl?.searchParams.get('limit')).toBe('20');
+          expect(capturedUrl?.searchParams.get('after')).toBe('cursor123');
+        });
+      });
+
+      describe('and properties are specified', () => {
+        it('includes property parameters', async () => {
+          const mockContacts = { results: [], paging: {} };
+          
+          let capturedUrl: URL | undefined;
+          server.use(
+            http.get(`${HUBSPOT_API_BASE}/crm/v3/objects/contacts`, ({ request }) => {
+              capturedUrl = new URL(request.url);
+              return HttpResponse.json(mockContacts);
+            })
+          );
+
+          const tool = HubSpotConnectorConfig.tools.GET_CONTACTS as MCPToolDefinition;
+          const mockContext = createMockConnectorContext({
+            credentials: { apiKey: 'test-api-key' },
+          });
+
+          await tool.handler(
+            { properties: ['email', 'firstname', 'company'] },
+            mockContext
+          );
+
+          const properties = capturedUrl?.searchParams.getAll('properties');
+          expect(properties).toEqual(['email', 'firstname', 'company']);
+        });
+      });
+    });
+
+    describe('when API returns an error', () => {
+      it('returns error message', async () => {
+        server.use(
+          http.get(`${HUBSPOT_API_BASE}/crm/v3/objects/contacts`, () => {
+            return HttpResponse.text('Invalid API key', { status: 401 });
+          })
+        );
+
+        const tool = HubSpotConnectorConfig.tools.GET_CONTACTS as MCPToolDefinition;
+        const mockContext = createMockConnectorContext({
+          credentials: { apiKey: 'invalid-key' },
+        });
+
+        const result = await tool.handler({}, mockContext);
+        expect(result).toContain('Failed to fetch contacts');
+        expect(result).toContain('401');
+      });
+    });
+  });
+
+  describe('.GET_DEALS', () => {
+    describe('when fetching deals successfully', () => {
+      it('returns a list of deals', async () => {
+        const mockDeals = {
+          results: [
+            {
+              id: '1',
+              properties: {
+                dealname: 'Big Deal',
+                amount: '10000',
+                dealstage: 'closedwon',
+              },
+            },
+          ],
+          paging: {},
+        };
+
+        server.use(
+          http.get(`${HUBSPOT_API_BASE}/crm/v3/objects/deals`, () => {
+            return HttpResponse.json(mockDeals);
+          })
+        );
+
+        const tool = HubSpotConnectorConfig.tools.GET_DEALS as MCPToolDefinition;
+        const mockContext = createMockConnectorContext({
+          credentials: { apiKey: 'test-api-key' },
+        });
+
+        const actual = await tool.handler(
+          { limit: 10 },
+          mockContext
+        );
+
+        const content = JSON.parse(actual);
+        expect(content.results).toHaveLength(1);
+        expect(content.results[0].properties.dealname).toBe('Big Deal');
+      });
+
+      describe('and pagination is provided', () => {
+        it('includes pagination parameters', async () => {
+          const mockDeals = { results: [], paging: {} };
+          
+          let capturedUrl: URL | undefined;
+          server.use(
+            http.get(`${HUBSPOT_API_BASE}/crm/v3/objects/deals`, ({ request }) => {
+              capturedUrl = new URL(request.url);
+              return HttpResponse.json(mockDeals);
+            })
+          );
+
+          const tool = HubSpotConnectorConfig.tools.GET_DEALS as MCPToolDefinition;
+          const mockContext = createMockConnectorContext({
+            credentials: { apiKey: 'test-api-key' },
+          });
+
+          await tool.handler(
+            { limit: 50, after: 'next-page' },
+            mockContext
+          );
+
+          expect(capturedUrl?.searchParams.get('limit')).toBe('50');
+          expect(capturedUrl?.searchParams.get('after')).toBe('next-page');
+        });
+      });
+    });
+
+    describe('when API returns an error', () => {
+      it('returns error message', async () => {
+        server.use(
+          http.get(`${HUBSPOT_API_BASE}/crm/v3/objects/deals`, () => {
+            return HttpResponse.text('Forbidden', { status: 403 });
+          })
+        );
+
+        const tool = HubSpotConnectorConfig.tools.GET_DEALS as MCPToolDefinition;
+        const mockContext = createMockConnectorContext({
+          credentials: { apiKey: 'test-api-key' },
+        });
+
+        const result = await tool.handler({}, mockContext);
+        expect(result).toContain('Failed to fetch deals');
+        expect(result).toContain('403');
+      });
+    });
+  });
+
+  describe('.CREATE_CONTACT', () => {
+    describe('when creating a contact successfully', () => {
+      it('returns the created contact', async () => {
+        const createdContact = {
+          id: '123',
+          properties: {
+            email: 'new@example.com',
+            firstname: 'Jane',
+            lastname: 'Smith',
+          },
+        };
+
+        server.use(
+          http.post(`${HUBSPOT_API_BASE}/crm/v3/objects/contacts`, () => {
+            return HttpResponse.json(createdContact);
+          })
+        );
+
+        const tool = HubSpotConnectorConfig.tools.CREATE_CONTACT as MCPToolDefinition;
+        const mockContext = createMockConnectorContext({
+          credentials: { apiKey: 'test-api-key' },
+        });
+
+        const actual = await tool.handler(
+          {
+            email: 'new@example.com',
+            firstname: 'Jane',
+            lastname: 'Smith',
+          },
+          mockContext
+        );
+
+        const content = JSON.parse(actual);
+        expect(content.id).toBe('123');
+        expect(content.properties.email).toBe('new@example.com');
+      });
+
+      describe('and additional properties are provided', () => {
+        it('includes all properties in the request', async () => {
+          let capturedBody: Record<string, unknown> = {};
+          server.use(
+            http.post(`${HUBSPOT_API_BASE}/crm/v3/objects/contacts`, async ({ request }) => {
+              capturedBody = await request.json() as Record<string, unknown>;
+              return HttpResponse.json({ id: '123', properties: {} });
+            })
+          );
+
+          const tool = HubSpotConnectorConfig.tools.CREATE_CONTACT as MCPToolDefinition;
+          const mockContext = createMockConnectorContext({
+            credentials: { apiKey: 'test-api-key' },
+          });
+
+          await tool.handler(
+            {
+              email: 'test@example.com',
+              company: 'Test Corp',
+              phone: '555-1234',
+              website: 'https://example.com',
+              additionalProperties: {
+                custom_field: 'value',
+              },
+            },
+            mockContext
+          );
+
+          const properties = capturedBody.properties as Record<string, unknown>;
+          expect(properties.email).toBe('test@example.com');
+          expect(properties.company).toBe('Test Corp');
+          expect(properties.phone).toBe('555-1234');
+          expect(properties.website).toBe('https://example.com');
+          expect(properties.custom_field).toBe('value');
+        });
+      });
+    });
+
+    describe('when API returns an error', () => {
+      it('returns error message', async () => {
+        server.use(
+          http.post(`${HUBSPOT_API_BASE}/crm/v3/objects/contacts`, () => {
+            return HttpResponse.text('Contact already exists', { status: 409 });
+          })
+        );
+
+        const tool = HubSpotConnectorConfig.tools.CREATE_CONTACT as MCPToolDefinition;
+        const mockContext = createMockConnectorContext({
+          credentials: { apiKey: 'test-api-key' },
+        });
+
+        const result = await tool.handler(
+          { email: 'duplicate@example.com' },
+          mockContext
+        );
+        expect(result).toContain('Failed to create contact');
+        expect(result).toContain('409');
+      });
+    });
+  });
+
+  describe('.CREATE_DEAL', () => {
+    describe('when creating a deal successfully', () => {
+      it('returns the created deal', async () => {
+        const createdDeal = {
+          id: '456',
+          properties: {
+            dealname: 'New Deal',
+            amount: '50000',
+            dealstage: 'presentationscheduled',
+          },
+        };
+
+        server.use(
+          http.post(`${HUBSPOT_API_BASE}/crm/v3/objects/deals`, () => {
+            return HttpResponse.json(createdDeal);
+          })
+        );
+
+        const tool = HubSpotConnectorConfig.tools.CREATE_DEAL as MCPToolDefinition;
+        const mockContext = createMockConnectorContext({
+          credentials: { apiKey: 'test-api-key' },
+        });
+
+        const actual = await tool.handler(
+          {
+            dealname: 'New Deal',
+            amount: '50000',
+            dealstage: 'presentationscheduled',
+          },
+          mockContext
+        );
+
+        const content = JSON.parse(actual);
+        expect(content.id).toBe('456');
+        expect(content.properties.dealname).toBe('New Deal');
+      });
+
+      describe('and all optional properties are provided', () => {
+        it('includes all properties in the request', async () => {
+          let capturedBody: Record<string, unknown> = {};
+          server.use(
+            http.post(`${HUBSPOT_API_BASE}/crm/v3/objects/deals`, async ({ request }) => {
+              capturedBody = await request.json() as Record<string, unknown>;
+              return HttpResponse.json({ id: '456', properties: {} });
+            })
+          );
+
+          const tool = HubSpotConnectorConfig.tools.CREATE_DEAL as MCPToolDefinition;
+          const mockContext = createMockConnectorContext({
+            credentials: { apiKey: 'test-api-key' },
+          });
+
+          await tool.handler(
+            {
+              dealname: 'Big Deal',
+              amount: '100000',
+              dealstage: 'qualifiedtobuy',
+              pipeline: 'default',
+              closedate: '2024-12-31',
+              hubspot_owner_id: 'owner123',
+              additionalProperties: {
+                custom_property: 'custom_value',
+              },
+            },
+            mockContext
+          );
+
+          const properties = capturedBody.properties as Record<string, unknown>;
+          expect(properties.dealname).toBe('Big Deal');
+          expect(properties.amount).toBe('100000');
+          expect(properties.dealstage).toBe('qualifiedtobuy');
+          expect(properties.pipeline).toBe('default');
+          expect(properties.closedate).toBe('2024-12-31');
+          expect(properties.hubspot_owner_id).toBe('owner123');
+          expect(properties.custom_property).toBe('custom_value');
+        });
+      });
+    });
+
+    describe('when API returns an error', () => {
+      it('returns error message', async () => {
+        server.use(
+          http.post(`${HUBSPOT_API_BASE}/crm/v3/objects/deals`, () => {
+            return HttpResponse.text('Invalid pipeline', { status: 400 });
+          })
+        );
+
+        const tool = HubSpotConnectorConfig.tools.CREATE_DEAL as MCPToolDefinition;
+        const mockContext = createMockConnectorContext({
+          credentials: { apiKey: 'test-api-key' },
+        });
+
+        const result = await tool.handler(
+          { dealname: 'Test Deal' },
+          mockContext
+        );
+        expect(result).toContain('Failed to create deal');
+        expect(result).toContain('400');
+      });
+    });
+  });
+});

--- a/packages/mcp-connectors/src/connectors/hubspot.spec.ts
+++ b/packages/mcp-connectors/src/connectors/hubspot.spec.ts
@@ -1,9 +1,9 @@
-import { describe, expect, it, beforeAll, afterAll, afterEach } from 'vitest';
 import type { MCPToolDefinition } from '@stackone/mcp-config-types';
-import { createMockConnectorContext } from '../__mocks__/context';
-import { HubSpotConnectorConfig } from './hubspot';
 import { http, HttpResponse } from 'msw';
 import { setupServer } from 'msw/node';
+import { afterAll, afterEach, beforeAll, describe, expect, it } from 'vitest';
+import { createMockConnectorContext } from '../__mocks__/context';
+import { HubSpotConnectorConfig } from './hubspot';
 
 const HUBSPOT_API_BASE = 'https://api.hubapi.com';
 
@@ -46,10 +46,7 @@ describe('#HubSpotConnector', () => {
           credentials: { apiKey: 'test-api-key' },
         });
 
-        const actual = await tool.handler(
-          { limit: 10 },
-          mockContext
-        );
+        const actual = await tool.handler({ limit: 10 }, mockContext);
 
         const content = JSON.parse(actual);
         expect(content.results).toHaveLength(1);
@@ -59,7 +56,7 @@ describe('#HubSpotConnector', () => {
       describe('and pagination is provided', () => {
         it('includes pagination parameters', async () => {
           const mockContacts = { results: [], paging: {} };
-          
+
           let capturedUrl: URL | undefined;
           server.use(
             http.get(`${HUBSPOT_API_BASE}/crm/v3/objects/contacts`, ({ request }) => {
@@ -73,10 +70,7 @@ describe('#HubSpotConnector', () => {
             credentials: { apiKey: 'test-api-key' },
           });
 
-          await tool.handler(
-            { limit: 20, after: 'cursor123' },
-            mockContext
-          );
+          await tool.handler({ limit: 20, after: 'cursor123' }, mockContext);
 
           expect(capturedUrl?.searchParams.get('limit')).toBe('20');
           expect(capturedUrl?.searchParams.get('after')).toBe('cursor123');
@@ -86,7 +80,7 @@ describe('#HubSpotConnector', () => {
       describe('and properties are specified', () => {
         it('includes property parameters', async () => {
           const mockContacts = { results: [], paging: {} };
-          
+
           let capturedUrl: URL | undefined;
           server.use(
             http.get(`${HUBSPOT_API_BASE}/crm/v3/objects/contacts`, ({ request }) => {
@@ -159,10 +153,7 @@ describe('#HubSpotConnector', () => {
           credentials: { apiKey: 'test-api-key' },
         });
 
-        const actual = await tool.handler(
-          { limit: 10 },
-          mockContext
-        );
+        const actual = await tool.handler({ limit: 10 }, mockContext);
 
         const content = JSON.parse(actual);
         expect(content.results).toHaveLength(1);
@@ -172,7 +163,7 @@ describe('#HubSpotConnector', () => {
       describe('and pagination is provided', () => {
         it('includes pagination parameters', async () => {
           const mockDeals = { results: [], paging: {} };
-          
+
           let capturedUrl: URL | undefined;
           server.use(
             http.get(`${HUBSPOT_API_BASE}/crm/v3/objects/deals`, ({ request }) => {
@@ -186,10 +177,7 @@ describe('#HubSpotConnector', () => {
             credentials: { apiKey: 'test-api-key' },
           });
 
-          await tool.handler(
-            { limit: 50, after: 'next-page' },
-            mockContext
-          );
+          await tool.handler({ limit: 50, after: 'next-page' }, mockContext);
 
           expect(capturedUrl?.searchParams.get('limit')).toBe('50');
           expect(capturedUrl?.searchParams.get('after')).toBe('next-page');
@@ -258,10 +246,13 @@ describe('#HubSpotConnector', () => {
         it('includes all properties in the request', async () => {
           let capturedBody: Record<string, unknown> = {};
           server.use(
-            http.post(`${HUBSPOT_API_BASE}/crm/v3/objects/contacts`, async ({ request }) => {
-              capturedBody = await request.json() as Record<string, unknown>;
-              return HttpResponse.json({ id: '123', properties: {} });
-            })
+            http.post(
+              `${HUBSPOT_API_BASE}/crm/v3/objects/contacts`,
+              async ({ request }) => {
+                capturedBody = (await request.json()) as Record<string, unknown>;
+                return HttpResponse.json({ id: '123', properties: {} });
+              }
+            )
           );
 
           const tool = HubSpotConnectorConfig.tools.CREATE_CONTACT as MCPToolDefinition;
@@ -357,7 +348,7 @@ describe('#HubSpotConnector', () => {
           let capturedBody: Record<string, unknown> = {};
           server.use(
             http.post(`${HUBSPOT_API_BASE}/crm/v3/objects/deals`, async ({ request }) => {
-              capturedBody = await request.json() as Record<string, unknown>;
+              capturedBody = (await request.json()) as Record<string, unknown>;
               return HttpResponse.json({ id: '456', properties: {} });
             })
           );
@@ -407,10 +398,7 @@ describe('#HubSpotConnector', () => {
           credentials: { apiKey: 'test-api-key' },
         });
 
-        const result = await tool.handler(
-          { dealname: 'Test Deal' },
-          mockContext
-        );
+        const result = await tool.handler({ dealname: 'Test Deal' }, mockContext);
         expect(result).toContain('Failed to create deal');
         expect(result).toContain('400');
       });

--- a/packages/mcp-connectors/src/connectors/hubspot.ts
+++ b/packages/mcp-connectors/src/connectors/hubspot.ts
@@ -1,0 +1,264 @@
+import { mcpConnectorConfig } from '@stackone/mcp-config-types';
+import { z } from 'zod';
+
+class HubSpotClient {
+  private baseUrl = 'https://api.hubapi.com';
+  private headers: Record<string, string>;
+
+  constructor(apiKey: string) {
+    this.headers = {
+      Authorization: `Bearer ${apiKey}`,
+      Accept: 'application/json',
+    };
+  }
+
+  async getContacts(params: {
+    limit?: number;
+    after?: string;
+    properties?: string[];
+  }) {
+    const searchParams = new URLSearchParams();
+    if (params.limit) searchParams.append('limit', String(params.limit));
+    if (params.after) searchParams.append('after', params.after);
+    if (params.properties?.length) {
+      for (const prop of params.properties) {
+        searchParams.append('properties', prop);
+      }
+    }
+
+    const response = await fetch(
+      `${this.baseUrl}/crm/v3/objects/contacts?${searchParams.toString()}`,
+      {
+        method: 'GET',
+        headers: this.headers,
+      }
+    );
+
+    if (!response.ok) {
+      const error = await response.text();
+      throw new Error(`HubSpot API error: ${response.status} - ${error}`);
+    }
+
+    return response.json();
+  }
+
+  async getDeals(params: {
+    limit?: number;
+    after?: string;
+    properties?: string[];
+  }) {
+    const searchParams = new URLSearchParams();
+    if (params.limit) searchParams.append('limit', String(params.limit));
+    if (params.after) searchParams.append('after', params.after);
+    if (params.properties?.length) {
+      for (const prop of params.properties) {
+        searchParams.append('properties', prop);
+      }
+    }
+
+    const response = await fetch(
+      `${this.baseUrl}/crm/v3/objects/deals?${searchParams.toString()}`,
+      {
+        method: 'GET',
+        headers: this.headers,
+      }
+    );
+
+    if (!response.ok) {
+      const error = await response.text();
+      throw new Error(`HubSpot API error: ${response.status} - ${error}`);
+    }
+
+    return response.json();
+  }
+
+  async createContact(properties: Record<string, unknown>) {
+    const response = await fetch(`${this.baseUrl}/crm/v3/objects/contacts`, {
+      method: 'POST',
+      headers: {
+        ...this.headers,
+        'Content-Type': 'application/json',
+      },
+      body: JSON.stringify({ properties }),
+    });
+
+    if (!response.ok) {
+      const error = await response.text();
+      throw new Error(`HubSpot API error: ${response.status} - ${error}`);
+    }
+
+    return response.json();
+  }
+
+  async createDeal(properties: Record<string, unknown>) {
+    const response = await fetch(`${this.baseUrl}/crm/v3/objects/deals`, {
+      method: 'POST',
+      headers: {
+        ...this.headers,
+        'Content-Type': 'application/json',
+      },
+      body: JSON.stringify({ properties }),
+    });
+
+    if (!response.ok) {
+      const error = await response.text();
+      throw new Error(`HubSpot API error: ${response.status} - ${error}`);
+    }
+
+    return response.json();
+  }
+}
+
+export const HubSpotConnectorConfig = mcpConnectorConfig({
+  name: 'HubSpot',
+  key: 'hubspot',
+  version: '1.0.0',
+  credentials: z.object({
+    apiKey: z
+      .string()
+      .describe('Your HubSpot API key from Settings > Integrations > API Key'),
+  }),
+  logo: 'https://stackone-logos.com/api/hubspot/filled/svg',
+  setup: z.object({}),
+  examplePrompt:
+    'Get my HubSpot contacts and create a new deal for $10,000 with Acme Corp',
+  tools: (tool) => ({
+    GET_CONTACTS: tool({
+      name: 'hubspot_get_contacts',
+      description: 'Retrieve a list of contacts from HubSpot CRM',
+      schema: z.object({
+        limit: z.number().default(10).describe('Number of contacts to return (max 100)'),
+        after: z.string().optional().describe('Pagination cursor for next page'),
+        properties: z
+          .array(z.string())
+          .optional()
+          .describe('List of contact properties to include in the response'),
+      }),
+      handler: async (args, context) => {
+        try {
+          const { apiKey } = await context.getCredentials();
+          const client = new HubSpotClient(apiKey);
+          const data = await client.getContacts({
+            limit: args.limit,
+            after: args.after,
+            properties: args.properties,
+          });
+          return JSON.stringify(data, null, 2);
+        } catch (error) {
+          return `Failed to fetch contacts: ${error instanceof Error ? error.message : String(error)}`;
+        }
+      },
+    }),
+    GET_DEALS: tool({
+      name: 'hubspot_get_deals',
+      description: 'Retrieve a list of deals from HubSpot CRM',
+      schema: z.object({
+        limit: z.number().default(10).describe('Number of deals to return (max 100)'),
+        after: z.string().optional().describe('Pagination cursor for next page'),
+        properties: z
+          .array(z.string())
+          .optional()
+          .describe('List of deal properties to include in the response'),
+      }),
+      handler: async (args, context) => {
+        try {
+          const { apiKey } = await context.getCredentials();
+          const client = new HubSpotClient(apiKey);
+          const data = await client.getDeals({
+            limit: args.limit,
+            after: args.after,
+            properties: args.properties,
+          });
+          return JSON.stringify(data, null, 2);
+        } catch (error) {
+          return `Failed to fetch deals: ${error instanceof Error ? error.message : String(error)}`;
+        }
+      },
+    }),
+    CREATE_CONTACT: tool({
+      name: 'hubspot_create_contact',
+      description: 'Create a new contact in HubSpot CRM',
+      schema: z.object({
+        email: z.string().describe('Email address of the contact'),
+        firstname: z.string().optional().describe('First name of the contact'),
+        lastname: z.string().optional().describe('Last name of the contact'),
+        company: z.string().optional().describe('Company name'),
+        phone: z.string().optional().describe('Phone number'),
+        website: z.string().optional().describe('Website URL'),
+        additionalProperties: z
+          .record(z.any())
+          .optional()
+          .describe('Additional custom properties for the contact'),
+      }),
+      handler: async (args, context) => {
+        try {
+          const { apiKey } = await context.getCredentials();
+          const client = new HubSpotClient(apiKey);
+
+          const properties: Record<string, unknown> = {
+            email: args.email,
+          };
+
+          if (args.firstname) properties.firstname = args.firstname;
+          if (args.lastname) properties.lastname = args.lastname;
+          if (args.company) properties.company = args.company;
+          if (args.phone) properties.phone = args.phone;
+          if (args.website) properties.website = args.website;
+
+          if (args.additionalProperties) {
+            Object.assign(properties, args.additionalProperties);
+          }
+
+          const data = await client.createContact(properties);
+          return JSON.stringify(data, null, 2);
+        } catch (error) {
+          return `Failed to create contact: ${error instanceof Error ? error.message : String(error)}`;
+        }
+      },
+    }),
+    CREATE_DEAL: tool({
+      name: 'hubspot_create_deal',
+      description: 'Create a new deal in HubSpot CRM',
+      schema: z.object({
+        dealname: z.string().describe('Name of the deal'),
+        amount: z.string().optional().describe('Deal amount'),
+        dealstage: z.string().optional().describe('Stage of the deal'),
+        pipeline: z.string().optional().describe('Pipeline ID'),
+        closedate: z
+          .string()
+          .optional()
+          .describe('Expected close date (timestamp or ISO 8601)'),
+        hubspot_owner_id: z.string().optional().describe('Owner ID for the deal'),
+        additionalProperties: z
+          .record(z.any())
+          .optional()
+          .describe('Additional custom properties for the deal'),
+      }),
+      handler: async (args, context) => {
+        try {
+          const { apiKey } = await context.getCredentials();
+          const client = new HubSpotClient(apiKey);
+
+          const properties: Record<string, unknown> = {
+            dealname: args.dealname,
+          };
+
+          if (args.amount) properties.amount = args.amount;
+          if (args.dealstage) properties.dealstage = args.dealstage;
+          if (args.pipeline) properties.pipeline = args.pipeline;
+          if (args.closedate) properties.closedate = args.closedate;
+          if (args.hubspot_owner_id) properties.hubspot_owner_id = args.hubspot_owner_id;
+
+          if (args.additionalProperties) {
+            Object.assign(properties, args.additionalProperties);
+          }
+
+          const data = await client.createDeal(properties);
+          return JSON.stringify(data, null, 2);
+        } catch (error) {
+          return `Failed to create deal: ${error instanceof Error ? error.message : String(error)}`;
+        }
+      },
+    }),
+  }),
+});

--- a/packages/mcp-connectors/src/index.ts
+++ b/packages/mcp-connectors/src/index.ts
@@ -16,6 +16,7 @@ import { FirefliesConnectorConfig } from './connectors/fireflies';
 import { GitHubConnectorConfig } from './connectors/github';
 import { GoogleDriveConnectorConfig } from './connectors/google-drive';
 import { HiBobConnectorConfig } from './connectors/hibob';
+import { HubSpotConnectorConfig } from './connectors/hubspot';
 import { IncidentConnectorConfig } from './connectors/incident';
 import { JiraConnectorConfig } from './connectors/jira';
 import { LangsmithConnectorConfig } from './connectors/langsmith';
@@ -58,6 +59,7 @@ export const Connectors: readonly MCPConnectorConfig[] = [
   GitHubConnectorConfig,
   GoogleDriveConnectorConfig,
   HiBobConnectorConfig,
+  HubSpotConnectorConfig,
   IncidentConnectorConfig,
   FirefliesConnectorConfig,
   JiraConnectorConfig,
@@ -100,6 +102,7 @@ export {
   GitHubConnectorConfig,
   GoogleDriveConnectorConfig,
   HiBobConnectorConfig,
+  HubSpotConnectorConfig,
   IncidentConnectorConfig,
   FirefliesConnectorConfig,
   JiraConnectorConfig,


### PR DESCRIPTION

    
<!-- This is an auto-generated description by cubic. -->

## Summary by cubic
Adds a HubSpot connector with tools to list and create contacts and deals. Registers the connector, adds tests, and updates docs for logo usage.

- **New Features**
  - HubSpotConnectorConfig with tools:
    - hubspot_get_contacts (limit, after, properties)
    - hubspot_get_deals (limit, after, properties)
    - hubspot_create_contact (email, optional fields, additionalProperties)
    - hubspot_create_deal (dealname, optional fields, additionalProperties)
  - Requires apiKey credential; returns JSON with basic error messaging.
  - Registered in connectors index and exports.

- **Refactors**
  - Testing: createMockConnectorContext now accepts credentials/setup/data/cache; added MSW tests covering pagination, property selection, and error paths for all tools.
  - Docs: added logo guidance; prefer stackone-logos.com (connector key, filled/icon, svg/png).

<!-- End of auto-generated description by cubic. -->

