### PR TITLE
chore: update claude job triggers with additional user

### DIFF
--- a/.github/workflows/claude.yml
+++ b/.github/workflows/claude.yml
@@ -14,7 +14,7 @@ jobs:
   claude:
     # Only run when mattzcarey tags @claude
     if: |
-      (github.actor == 'mattzcarey' || github.actor == 'willleeney' || github.actor == 'brycetoz' || github.actor == 'glebedel' || github.actor == 'ryoppippi' || github.actor == 'nicolasbelissent') && (
+      (github.actor == 'mattzcarey' || github.actor == 'willleeney' || github.actor == 'brycetoz' || github.actor == 'glebedel' || github.actor == 'ryoppippi' || github.actor == 'NicolasBelissent' || github.actor == 'desocode') && (
         (github.event_name == 'issue_comment' && contains(github.event.comment.body, '@claude')) ||
         (github.event_name == 'pull_request_review_comment' && contains(github.event.comment.body, '@claude')) ||
         (github.event_name == 'pull_request_review' && contains(github.event.review.body, '@claude')) ||


### PR DESCRIPTION
Added 'nicolasbelissent' to the list of users who can trigger the claude job.
    
<!-- This is an auto-generated description by cubic. -->
---

## Summary by cubic
Extends the GitHub Actions claude workflow to include nicolasbelissent as an authorized actor. They can now trigger the job by tagging @claude in issue comments, PR comments, review comments, or reviews.

<!-- End of auto-generated description by cubic. -->

