### PR TITLE
🏗️🏗️🏗️ add beeper MCP

### DIFF
--- a/packages/mcp-connectors/src/connectors/beeper.spec.ts
+++ b/packages/mcp-connectors/src/connectors/beeper.spec.ts
@@ -11,7 +11,7 @@ beforeAll(() => server.listen({ onUnhandledRequest: 'error' }));
 afterEach(() => server.resetHandlers());
 afterAll(() => server.close());
 
-const BASE = 'https://chat.beeper.com';
+const BASE = 'http://localhost:23373';
 
 describe('#BeeperConnector', () => {
   describe('.WHO_AM_I', () => {
@@ -84,7 +84,7 @@ describe('#BeeperConnector', () => {
         server.use(
           http.post(
             new RegExp(
-              '^https://chat\\.beeper\\.com/_matrix/client/v3/rooms/!room%3Abeeper\\.com/send/m\\.room\\.message/.+'
+              '^http://localhost:23373/_matrix/client/v3/rooms/!room%3Abeeper\\.com/send/m\\.room\\.message/.+'
             ),
             () => {
               return HttpResponse.json({ event_id: '$event123' });

--- a/packages/mcp-connectors/src/connectors/beeper.spec.ts
+++ b/packages/mcp-connectors/src/connectors/beeper.spec.ts
@@ -1,0 +1,112 @@
+import type { MCPToolDefinition } from '@stackone/mcp-config-types';
+import { http, HttpResponse } from 'msw';
+import { setupServer } from 'msw/node';
+import { afterAll, afterEach, beforeAll, describe, expect, it, vi } from 'vitest';
+import { createMockConnectorContext } from '../__mocks__/context';
+import { BeeperConnectorConfig } from './beeper';
+
+const server = setupServer();
+
+beforeAll(() => server.listen({ onUnhandledRequest: 'error' }));
+afterEach(() => server.resetHandlers());
+afterAll(() => server.close());
+
+const BASE = 'https://chat.beeper.com';
+
+describe('#BeeperConnector', () => {
+  describe('.WHO_AM_I', () => {
+    describe('when request is successful', () => {
+      it('returns current user identity', async () => {
+        server.use(
+          http.get(`${BASE}/_matrix/client/v3/account/whoami`, () => {
+            return HttpResponse.json({ user_id: '@test:beeper.com', device_id: 'DEV123' });
+          })
+        );
+
+        const tool = BeeperConnectorConfig.tools.WHO_AM_I as MCPToolDefinition;
+        const mockContext = createMockConnectorContext();
+        (mockContext.getCredentials as ReturnType<typeof vi.fn>).mockResolvedValue({
+          accessToken: 'syt_test',
+        });
+
+        const actual = await tool.handler({}, mockContext);
+        const parsed = JSON.parse(actual);
+        expect(parsed.user_id).toBe('@test:beeper.com');
+      });
+    });
+
+    describe('when unauthorized', () => {
+      it('returns error message', async () => {
+        server.use(
+          http.get(`${BASE}/_matrix/client/v3/account/whoami`, () => {
+            return HttpResponse.text('Unauthorized', { status: 401 });
+          })
+        );
+
+        const tool = BeeperConnectorConfig.tools.WHO_AM_I as MCPToolDefinition;
+        const mockContext = createMockConnectorContext();
+        (mockContext.getCredentials as ReturnType<typeof vi.fn>).mockResolvedValue({
+          accessToken: 'bad',
+        });
+
+        const actual = await tool.handler({}, mockContext);
+        expect(actual).toContain('Failed to get identity');
+      });
+    });
+  });
+
+  describe('.LIST_JOINED_ROOMS', () => {
+    describe('when there are joined rooms', () => {
+      it('returns joined room IDs', async () => {
+        server.use(
+          http.get(`${BASE}/_matrix/client/v3/joined_rooms`, () => {
+            return HttpResponse.json({ joined_rooms: ['!abc:beeper.com', '!xyz:beeper.com'] });
+          })
+        );
+
+        const tool = BeeperConnectorConfig.tools
+          .LIST_JOINED_ROOMS as MCPToolDefinition;
+        const mockContext = createMockConnectorContext();
+        (mockContext.getCredentials as ReturnType<typeof vi.fn>).mockResolvedValue({
+          accessToken: 'syt_test',
+        });
+
+        const actual = await tool.handler({}, mockContext);
+        const parsed = JSON.parse(actual);
+        expect(parsed.joined_rooms).toHaveLength(2);
+      });
+    });
+  });
+
+  describe('.SEND_MESSAGE', () => {
+    describe('when message is valid', () => {
+      it('sends a message to room', async () => {
+        server.use(
+          http.post(
+            new RegExp(
+              '^https://chat\\.beeper\\.com/_matrix/client/v3/rooms/!room%3Abeeper\\.com/send/m\\.room\\.message/.+'
+            ),
+            () => {
+              return HttpResponse.json({ event_id: '$event123' });
+            }
+          )
+        );
+
+        const tool = BeeperConnectorConfig.tools.SEND_MESSAGE as MCPToolDefinition;
+        const mockContext = createMockConnectorContext();
+        (mockContext.getCredentials as ReturnType<typeof vi.fn>).mockResolvedValue({
+          accessToken: 'syt_test',
+        });
+
+        const actual = await tool.handler(
+          { room_id: '!room:beeper.com', body: 'Hello world' },
+          mockContext
+        );
+        const parsed = JSON.parse(actual);
+        expect(parsed.event_id).toBe('$event123');
+      });
+    });
+  });
+});
+
+

--- a/packages/mcp-connectors/src/connectors/beeper.ts
+++ b/packages/mcp-connectors/src/connectors/beeper.ts
@@ -1,0 +1,302 @@
+import { mcpConnectorConfig } from '@stackone/mcp-config-types';
+import { z } from 'zod';
+
+// Beeper is built on Matrix. We use Matrix Client-Server API-compatible endpoints.
+// Docs reference: https://spec.matrix.org/latest/client-server-api/
+
+interface MatrixRoom {
+  room_id: string;
+  name?: string;
+  canonical_alias?: string;
+  avatar_url?: string;
+  topic?: string;
+  [key: string]: unknown;
+}
+
+interface MatrixJoinedRoomsResponse {
+  joined_rooms: string[];
+}
+
+interface MatrixWhoAmIResponse {
+  user_id: string;
+  device_id?: string;
+  [key: string]: unknown;
+}
+
+interface MatrixEventResponse {
+  event_id: string;
+}
+
+class BeeperMatrixClient {
+  private baseUrl: string;
+  private headers: { Authorization: string; 'Content-Type': string };
+
+  constructor(accessToken: string, baseUrl?: string) {
+    // Default Beeper homeserver base if not provided
+    this.baseUrl = (baseUrl || 'https://chat.beeper.com').replace(/\/$/, '');
+    this.headers = {
+      Authorization: `Bearer ${accessToken}`,
+      'Content-Type': 'application/json',
+    };
+  }
+
+  private async get<T>(path: string): Promise<T> {
+    const url = `${this.baseUrl}${path}`;
+    const res = await fetch(url, { headers: this.headers });
+    if (!res.ok) {
+      const text = await res.text();
+      throw new Error(`Beeper API error ${res.status}: ${text}`);
+    }
+    return res.json() as Promise<T>;
+  }
+
+  private async post<T>(path: string, body?: unknown): Promise<T> {
+    const url = `${this.baseUrl}${path}`;
+    const res = await fetch(url, {
+      method: 'POST',
+      headers: this.headers,
+      body: body ? JSON.stringify(body) : undefined,
+    });
+    if (!res.ok) {
+      const text = await res.text();
+      throw new Error(`Beeper API error ${res.status}: ${text}`);
+    }
+    return res.json() as Promise<T>;
+  }
+
+  async whoAmI(): Promise<MatrixWhoAmIResponse> {
+    return this.get('/_matrix/client/v3/account/whoami');
+  }
+
+  async listJoinedRooms(): Promise<MatrixJoinedRoomsResponse> {
+    return this.get('/_matrix/client/v3/joined_rooms');
+  }
+
+  async getRoomState(roomId: string): Promise<MatrixRoom> {
+    // Compose lightweight room details from common state events
+    const state = await this.get<{ events: Array<{ type: string; content: Record<string, unknown> }> }>(
+      `/_matrix/client/v3/rooms/${encodeURIComponent(roomId)}/state`
+    );
+    const room: MatrixRoom = { room_id: roomId };
+    for (const ev of state.events) {
+      if (ev.type === 'm.room.name') room.name = ev.content?.name as string | undefined;
+      if (ev.type === 'm.room.canonical_alias')
+        room.canonical_alias = ev.content?.alias as string | undefined;
+      if (ev.type === 'm.room.avatar') room.avatar_url = ev.content?.url as string | undefined;
+      if (ev.type === 'm.room.topic') room.topic = ev.content?.topic as string | undefined;
+    }
+    return room;
+  }
+
+  async sendMessage(roomId: string, body: string, msgtype = 'm.text'): Promise<MatrixEventResponse> {
+    // transactionId can be any unique string
+    const txnId = `mcp_${Date.now()}_${Math.random().toString(36).slice(2, 10)}`;
+    return this.post(
+      `/_matrix/client/v3/rooms/${encodeURIComponent(roomId)}/send/m.room.message/${txnId}`,
+      {
+        msgtype,
+        body,
+      }
+    );
+  }
+
+  async invite(roomId: string, userId: string): Promise<Record<string, unknown>> {
+    return this.post(`/_matrix/client/v3/rooms/${encodeURIComponent(roomId)}/invite`, {
+      user_id: userId,
+    });
+  }
+
+  async join(roomIdOrAlias: string): Promise<{ room_id: string }> {
+    return this.post(`/_matrix/client/v3/join/${encodeURIComponent(roomIdOrAlias)}`);
+  }
+
+  async leave(roomId: string): Promise<Record<string, unknown>> {
+    return this.post(`/_matrix/client/v3/rooms/${encodeURIComponent(roomId)}/leave`);
+  }
+
+  async getMessages(
+    roomId: string,
+    opts?: { dir?: 'b' | 'f'; limit?: number; from?: string }
+  ): Promise<{ chunk: unknown[]; end?: string; start?: string }> {
+    const params = new URLSearchParams();
+    params.set('dir', opts?.dir || 'b');
+    if (opts?.limit) params.set('limit', String(opts.limit));
+    if (opts?.from) params.set('from', opts.from);
+    return this.get(
+      `/_matrix/client/v3/rooms/${encodeURIComponent(roomId)}/messages?${params.toString()}`
+    );
+  }
+}
+
+export const BeeperConnectorConfig = mcpConnectorConfig({
+  name: 'Beeper',
+  key: 'beeper',
+  version: '1.0.0',
+  logo: 'https://stackone-logos.com/api/beeper/filled/svg',
+  credentials: z.object({
+    accessToken: z
+      .string()
+      .describe(
+        'Beeper/Matrix Access Token :: syt_xxx or Bearer token with Matrix client perms :: see Beeper developer docs'
+      ),
+    baseUrl: z
+      .string()
+      .url()
+      .optional()
+      .describe('Optional Beeper homeserver base URL (default https://chat.beeper.com)'),
+  }),
+  setup: z.object({}),
+  examplePrompt:
+    'Check my Beeper identity, list my joined rooms, send a message to a room, invite a user, and fetch the latest 20 messages.',
+  tools: (tool) => ({
+    WHO_AM_I: tool({
+      name: 'beeper_who_am_i',
+      description: 'Get the current Matrix user (whoami)',
+      schema: z.object({}),
+      handler: async (_args, context) => {
+        try {
+          const { accessToken, baseUrl } = await context.getCredentials();
+          const client = new BeeperMatrixClient(accessToken, baseUrl);
+          const me = await client.whoAmI();
+          return JSON.stringify(me, null, 2);
+        } catch (error) {
+          return `Failed to get identity: ${error instanceof Error ? error.message : String(error)}`;
+        }
+      },
+    }),
+    LIST_JOINED_ROOMS: tool({
+      name: 'beeper_list_joined_rooms',
+      description: 'List joined room IDs for the current user',
+      schema: z.object({}),
+      handler: async (_args, context) => {
+        try {
+          const { accessToken, baseUrl } = await context.getCredentials();
+          const client = new BeeperMatrixClient(accessToken, baseUrl);
+          const rooms = await client.listJoinedRooms();
+          return JSON.stringify(rooms, null, 2);
+        } catch (error) {
+          return `Failed to list joined rooms: ${error instanceof Error ? error.message : String(error)}`;
+        }
+      },
+    }),
+    GET_ROOM_INFO: tool({
+      name: 'beeper_get_room_info',
+      description: 'Get basic room info (name, alias, avatar, topic) via state',
+      schema: z.object({
+        room_id: z.string().describe('Room ID to fetch state for'),
+      }),
+      handler: async (args, context) => {
+        try {
+          const { accessToken, baseUrl } = await context.getCredentials();
+          const client = new BeeperMatrixClient(accessToken, baseUrl);
+          const room = await client.getRoomState(args.room_id);
+          return JSON.stringify(room, null, 2);
+        } catch (error) {
+          return `Failed to get room info: ${error instanceof Error ? error.message : String(error)}`;
+        }
+      },
+    }),
+    SEND_MESSAGE: tool({
+      name: 'beeper_send_message',
+      description: 'Send a text message to a room',
+      schema: z.object({
+        room_id: z.string().describe('Room ID'),
+        body: z.string().describe('Message body text'),
+        msgtype: z
+          .enum(['m.text', 'm.notice', 'm.emote'])
+          .optional()
+          .describe('Matrix message type (default m.text)'),
+      }),
+      handler: async (args, context) => {
+        try {
+          const { accessToken, baseUrl } = await context.getCredentials();
+          const client = new BeeperMatrixClient(accessToken, baseUrl);
+          const res = await client.sendMessage(args.room_id, args.body, args.msgtype);
+          return JSON.stringify(res, null, 2);
+        } catch (error) {
+          return `Failed to send message: ${error instanceof Error ? error.message : String(error)}`;
+        }
+      },
+    }),
+    INVITE_TO_ROOM: tool({
+      name: 'beeper_invite_to_room',
+      description: 'Invite a user to a room',
+      schema: z.object({
+        room_id: z.string().describe('Room ID'),
+        user_id: z.string().describe('Matrix user ID to invite (e.g., @user:beeper.com)'),
+      }),
+      handler: async (args, context) => {
+        try {
+          const { accessToken, baseUrl } = await context.getCredentials();
+          const client = new BeeperMatrixClient(accessToken, baseUrl);
+          const res = await client.invite(args.room_id, args.user_id);
+          return JSON.stringify(res, null, 2);
+        } catch (error) {
+          return `Failed to invite user: ${error instanceof Error ? error.message : String(error)}`;
+        }
+      },
+    }),
+    JOIN_ROOM: tool({
+      name: 'beeper_join_room',
+      description: 'Join a room by ID or alias',
+      schema: z.object({
+        room: z
+          .string()
+          .describe('Room ID or alias (e.g., !abc:beeper.com or #room:beeper.com)'),
+      }),
+      handler: async (args, context) => {
+        try {
+          const { accessToken, baseUrl } = await context.getCredentials();
+          const client = new BeeperMatrixClient(accessToken, baseUrl);
+          const res = await client.join(args.room);
+          return JSON.stringify(res, null, 2);
+        } catch (error) {
+          return `Failed to join room: ${error instanceof Error ? error.message : String(error)}`;
+        }
+      },
+    }),
+    LEAVE_ROOM: tool({
+      name: 'beeper_leave_room',
+      description: 'Leave a room',
+      schema: z.object({
+        room_id: z.string().describe('Room ID to leave'),
+      }),
+      handler: async (args, context) => {
+        try {
+          const { accessToken, baseUrl } = await context.getCredentials();
+          const client = new BeeperMatrixClient(accessToken, baseUrl);
+          const res = await client.leave(args.room_id);
+          return JSON.stringify(res, null, 2);
+        } catch (error) {
+          return `Failed to leave room: ${error instanceof Error ? error.message : String(error)}`;
+        }
+      },
+    }),
+    GET_MESSAGES: tool({
+      name: 'beeper_get_messages',
+      description: 'Get messages in a room with pagination',
+      schema: z.object({
+        room_id: z.string().describe('Room ID'),
+        from: z.string().optional().describe('Pagination token'),
+        dir: z.enum(['b', 'f']).optional().describe('Direction: b (backward), f (forward)'),
+        limit: z.number().optional().describe('Max number of events to return'),
+      }),
+      handler: async (args, context) => {
+        try {
+          const { accessToken, baseUrl } = await context.getCredentials();
+          const client = new BeeperMatrixClient(accessToken, baseUrl);
+          const res = await client.getMessages(args.room_id, {
+            from: args.from,
+            dir: args.dir,
+            limit: args.limit,
+          });
+          return JSON.stringify(res, null, 2);
+        } catch (error) {
+          return `Failed to get messages: ${error instanceof Error ? error.message : String(error)}`;
+        }
+      },
+    }),
+  }),
+});
+
+

--- a/packages/mcp-connectors/src/connectors/beeper.ts
+++ b/packages/mcp-connectors/src/connectors/beeper.ts
@@ -32,8 +32,8 @@ class BeeperMatrixClient {
   private headers: { Authorization: string; 'Content-Type': string };
 
   constructor(accessToken: string, baseUrl?: string) {
-    // Default Beeper homeserver base if not provided
-    this.baseUrl = (baseUrl || 'https://chat.beeper.com').replace(/\/$/, '');
+    // Default to local Beeper API if not provided
+    this.baseUrl = (baseUrl || 'http://localhost:23373').replace(/\/$/, '');
     this.headers = {
       Authorization: `Bearer ${accessToken}`,
       'Content-Type': 'application/json',
@@ -143,7 +143,9 @@ export const BeeperConnectorConfig = mcpConnectorConfig({
       .string()
       .url()
       .optional()
-      .describe('Optional Beeper homeserver base URL (default https://chat.beeper.com)'),
+      .describe(
+        'Optional Beeper API base URL. Defaults to local Beeper at http://localhost:23373'
+      ),
   }),
   setup: z.object({}),
   examplePrompt:

--- a/packages/mcp-connectors/src/index.ts
+++ b/packages/mcp-connectors/src/index.ts
@@ -5,6 +5,7 @@ import { AsanaConnectorConfig } from './connectors/asana';
 import { AttioConnectorConfig } from './connectors/attio';
 import { AwsConnectorConfig } from './connectors/aws';
 import { DatadogConnectorConfig } from './connectors/datadog';
+import { BeeperConnectorConfig } from './connectors/beeper';
 import { DeelConnectorConfig } from './connectors/deel';
 import { DeepseekConnectorConfig } from './connectors/deepseek';
 import { DocumentationConnectorConfig } from './connectors/documentation';
@@ -45,6 +46,7 @@ import { XeroConnectorConfig } from './connectors/xero';
 export const Connectors: readonly MCPConnectorConfig[] = [
   TestConnectorConfig,
   StackOneConnectorConfig,
+  BeeperConnectorConfig,
   AsanaConnectorConfig,
   AttioConnectorConfig,
   AwsConnectorConfig,
@@ -88,6 +90,7 @@ export const Connectors: readonly MCPConnectorConfig[] = [
 export {
   TestConnectorConfig,
   StackOneConnectorConfig,
+  BeeperConnectorConfig,
   AsanaConnectorConfig,
   AttioConnectorConfig,
   AwsConnectorConfig,


### PR DESCRIPTION
    
## Summary
Team: 17 

Added a Beeper MCP connector built on the Matrix Client-Server API to enable identity lookup, room management, and messaging. The connector is registered in the connectors index and exposes tools secured by an access token.

- **What is Beeper?** Beeper provides a single inbox for all your chats, supporting all the most popular messaging services, all in one app, so there is no switching between different chats.


- **Why it is cool**
  - Beeper MCP is only accessible locally, so secure by design
  - Give local LLM (e.g. `gpt-oss-20b`) access to your messages, no messages sent to external parties
  - Feed context from messages with/ a friend to auto-generate a calendar invite based on chat context if connected to your calendar MCP
  - Prioritize which chats are the most interesting

- **Features**
  - New Beeper connector with credentials: accessToken and optional baseUrl.
  - Tools: WHO_AM_I, LIST_JOINED_ROOMS, GET_ROOM_INFO, SEND_MESSAGE, INVITE_TO_ROOM, JOIN_ROOM, LEAVE_ROOM, GET_MESSAGES.
  - BeeperMatrixClient wraps Matrix endpoints with simple get/post helpers and readable error messages.
  - Tests cover whoami, joined rooms, and sending messages.
  - Added BeeperConnectorConfig to Connectors list and exports.

<!-- End of auto-generated description by cubic. -->

