### PR TITLE
Feature(Figma-jira-connector)

### DIFF
--- a/packages/mcp-connectors/src/connectors/figma_jira.spec.ts
+++ b/packages/mcp-connectors/src/connectors/figma_jira.spec.ts
@@ -1,0 +1,121 @@
+import { describe, expect, it } from "vitest";
+import type { MCPToolDefinition } from "@stackone/mcp-config-types";
+import { createMockConnectorContext } from "../__mocks__/context";
+import { FigmaJiraConnectorConfig } from "./figma_jira";
+
+describe("#FigmaJiraConnector", () => {
+  describe(".GET_FIGMA_FRAME", () => {
+    describe("when frameId is valid", () => {
+      it("returns frame data with name and comments", async () => {
+        const tool = FigmaJiraConnectorConfig.tools.GET_FIGMA_FRAME as MCPToolDefinition;
+        const mockContext = createMockConnectorContext();
+
+        const actual = await tool.handler({ 
+          fileId: "test-file-id", 
+          frameId: "test-frame-id" 
+        }, mockContext);
+
+        expect(actual).toBeDefined();
+        expect(typeof actual).toBe("string");
+      });
+    });
+
+    describe("when frameId does not exist", () => {
+      it("returns an error message", async () => {
+        const tool = FigmaJiraConnectorConfig.tools.GET_FIGMA_FRAME as MCPToolDefinition;
+        const mockContext = createMockConnectorContext();
+
+        const actual = await tool.handler({ 
+          fileId: "test-file-id", 
+          frameId: "invalid-frame-id" 
+        }, mockContext);
+
+        expect(actual).toBeDefined();
+        expect(typeof actual).toBe("string");
+      });
+    });
+  });
+
+  describe(".CREATE_JIRA_TICKET_FROM_FRAME", () => {
+    describe("when all parameters are valid", () => {
+      it("creates a Jira ticket with frame details", async () => {
+        const tool = FigmaJiraConnectorConfig.tools.CREATE_JIRA_TICKET_FROM_FRAME as MCPToolDefinition;
+        const mockContext = createMockConnectorContext();
+
+        const actual = await tool.handler({ 
+          fileId: "test-file-id", 
+          frameId: "test-frame-id",
+          projectKey: "TEST",
+          issueType: "Task"
+        }, mockContext);
+
+        expect(actual).toBeDefined();
+        expect(typeof actual).toBe("string");
+      });
+    });
+
+    describe("when using default project and issue type", () => {
+      it("creates a Jira ticket with default values", async () => {
+        const tool = FigmaJiraConnectorConfig.tools.CREATE_JIRA_TICKET_FROM_FRAME as MCPToolDefinition;
+        const mockContext = createMockConnectorContext();
+
+        const actual = await tool.handler({ 
+          fileId: "test-file-id", 
+          frameId: "test-frame-id"
+        }, mockContext);
+
+        expect(actual).toBeDefined();
+        expect(typeof actual).toBe("string");
+      });
+    });
+  });
+
+  describe(".GET_FIGMA_FILE_INFO", () => {
+    describe("when fileId is valid", () => {
+      it("returns file information", async () => {
+        const tool = FigmaJiraConnectorConfig.tools.GET_FIGMA_FILE_INFO as MCPToolDefinition;
+        const mockContext = createMockConnectorContext();
+
+        const actual = await tool.handler({ 
+          fileId: "test-file-id" 
+        }, mockContext);
+
+        expect(actual).toBeDefined();
+        expect(typeof actual).toBe("string");
+      });
+    });
+  });
+
+  describe(".SEARCH_FIGMA_FRAMES", () => {
+    describe("when search query is provided", () => {
+      it("returns matching frames", async () => {
+        const tool = FigmaJiraConnectorConfig.tools.SEARCH_FIGMA_FRAMES as MCPToolDefinition;
+        const mockContext = createMockConnectorContext();
+
+        const actual = await tool.handler({ 
+          fileId: "test-file-id", 
+          query: "button" 
+        }, mockContext);
+
+        expect(actual).toBeDefined();
+        expect(typeof actual).toBe("string");
+      });
+    });
+
+    describe("when maxResults is specified", () => {
+      it("limits the number of results", async () => {
+        const tool = FigmaJiraConnectorConfig.tools.SEARCH_FIGMA_FRAMES as MCPToolDefinition;
+        const mockContext = createMockConnectorContext();
+
+        const actual = await tool.handler({ 
+          fileId: "test-file-id", 
+          query: "frame", 
+          maxResults: 5 
+        }, mockContext);
+
+        expect(actual).toBeDefined();
+        expect(typeof actual).toBe("string");
+      });
+    });
+  });
+});

--- a/packages/mcp-connectors/src/connectors/figma_jira.ts
+++ b/packages/mcp-connectors/src/connectors/figma_jira.ts
@@ -1,0 +1,430 @@
+import { mcpConnectorConfig } from '@stackone/mcp-config-types';
+import { z } from 'zod';
+
+// Figma API types
+interface FigmaNode {
+  id: string;
+  name: string;
+  type: string;
+  children?: FigmaNode[];
+  comment?: FigmaComment[];
+}
+
+interface FigmaComment {
+  id: string;
+  text: string;
+  user: {
+    handle: string;
+    img_url: string;
+  };
+  created_at: string;
+  resolved_at?: string;
+}
+
+interface FigmaFileResponse {
+  nodes: Record<string, { document: FigmaNode }>;
+}
+
+interface FigmaFileInfo {
+  key: string;
+  name: string;
+  lastModified: string;
+  thumbnailUrl: string;
+  version: string;
+  document: {
+    name: string;
+    type: string;
+    children?: FigmaNode[];
+  };
+}
+
+// Jira API types
+interface JiraIssueFields {
+  project: { key: string };
+  summary: string;
+  description: {
+    type: string;
+    version: number;
+    content: Array<{
+      type: string;
+      content: Array<{
+        type: string;
+        text: string;
+      }>;
+    }>;
+  };
+  issuetype: { name: string };
+  [key: string]: unknown;
+}
+
+interface JiraCreateIssueRequest {
+  fields: JiraIssueFields;
+}
+
+interface JiraCreateIssueResponse {
+  id: string;
+  key: string;
+  self: string;
+}
+
+// Type guards
+function isFigmaFileResponse(data: unknown): data is FigmaFileResponse {
+  return (
+    typeof data === 'object' &&
+    data !== null &&
+    'nodes' in data &&
+    typeof (data as any).nodes === 'object'
+  );
+}
+
+function isFigmaFileInfo(data: unknown): data is FigmaFileInfo {
+  return (
+    typeof data === 'object' &&
+    data !== null &&
+    'key' in data &&
+    'name' in data &&
+    'document' in data
+  );
+}
+
+function isJiraCreateIssueResponse(data: unknown): data is JiraCreateIssueResponse {
+  return (
+    typeof data === 'object' &&
+    data !== null &&
+    'id' in data &&
+    'key' in data &&
+    'self' in data
+  );
+}
+
+export const FigmaJiraConnectorConfig = mcpConnectorConfig({
+  name: 'Figma Jira',
+  key: 'figma_jira',
+  version: '1.0.0',
+  description: 'Connect Figma designs to Jira issues for seamless design-to-development workflow',
+  logo: 'https://stackone-logos.com/api/disco/filled/svg',
+  credentials: z.object({
+    figmaToken: z.string().describe('Figma Personal Access Token'),
+    jiraEmail: z.string().describe('Jira account email address'),
+    jiraApiToken: z.string().describe('Jira API token (not password)'),
+    jiraBaseUrl: z.string().describe('Jira instance URL (e.g., https://your-domain.atlassian.net)'),
+  }),
+  setup: z.object({
+    defaultProjectKey: z.string().describe('Default Jira project key for new issues'),
+    defaultIssueType: z.string().describe('Default issue type (e.g., "Task", "Story", "Bug")'),
+  }),
+  examplePrompt: 'Create a Jira ticket from a Figma frame with its comments and design details',
+  tools: (tool) => ({
+    GET_FIGMA_FRAME: tool({
+      name: 'figma_jira_get_frame',
+      description: 'Retrieve frame data from Figma including name, structure, and comments',
+      schema: z.object({
+        fileId: z.string().describe('Figma file ID (from the file URL)'),
+        frameId: z.string().describe('Frame node ID to retrieve'),
+      }),
+      handler: async (args, context) => {
+        try {
+          const { figmaToken } = await context.getCredentials();
+          const url = `https://api.figma.com/v1/files/${args.fileId}/nodes?ids=${args.frameId}`;
+          
+          const response = await fetch(url, {
+            headers: { 'X-Figma-Token': figmaToken }
+          });
+          
+          if (!response.ok) {
+            throw new Error(`Figma API error: ${response.status} ${response.statusText}`);
+          }
+          
+          const rawData = await response.json();
+          if (!isFigmaFileResponse(rawData)) {
+            throw new Error('Invalid response format from Figma API');
+          }
+          
+          const data: FigmaFileResponse = rawData;
+          const frame = data.nodes[args.frameId]?.document;
+          
+          if (!frame) {
+            return `Frame with ID ${args.frameId} not found in file ${args.fileId}`;
+          }
+          
+          const result = {
+            frameId: frame.id,
+            name: frame.name,
+            type: frame.type,
+            comments: frame.comment || [],
+            childrenCount: frame.children?.length || 0
+          };
+          
+          return JSON.stringify(result, null, 2);
+        } catch (error) {
+          return `Failed to get Figma frame: ${error instanceof Error ? error.message : String(error)}`;
+        }
+      },
+    }),
+
+    CREATE_JIRA_TICKET_FROM_FRAME: tool({
+      name: 'figma_jira_create_ticket_from_frame',
+      description: 'Create a Jira issue from a Figma frame, including frame details and comments',
+      schema: z.object({
+        fileId: z.string().describe('Figma file ID (from the file URL)'),
+        frameId: z.string().describe('Frame node ID to create ticket from'),
+        projectKey: z.string().optional().describe('Jira project key (uses default if not provided)'),
+        issueType: z.string().optional().describe('Issue type (uses default if not provided)'),
+        summary: z.string().optional().describe('Custom summary (uses frame name if not provided)'),
+        description: z.string().optional().describe('Additional description to append to frame details'),
+      }),
+      handler: async (args, context) => {
+        try {
+          const { figmaToken, jiraEmail, jiraApiToken, jiraBaseUrl } = await context.getCredentials();
+          const { defaultProjectKey, defaultIssueType } = await context.getSetup();
+          
+          // Get Figma frame data
+          const figmaUrl = `https://api.figma.com/v1/files/${args.fileId}/nodes?ids=${args.frameId}`;
+          const figmaResponse = await fetch(figmaUrl, {
+            headers: { 'X-Figma-Token': figmaToken }
+          });
+          
+          if (!figmaResponse.ok) {
+            throw new Error(`Figma API error: ${figmaResponse.status} ${figmaResponse.statusText}`);
+          }
+          
+          const rawFigmaData = await figmaResponse.json();
+          if (!isFigmaFileResponse(rawFigmaData)) {
+            throw new Error('Invalid response format from Figma API');
+          }
+          
+          const figmaData: FigmaFileResponse = rawFigmaData;
+          const frame = figmaData.nodes[args.frameId]?.document;
+          
+          if (!frame) {
+            return `Frame with ID ${args.frameId} not found in file ${args.fileId}`;
+          }
+          
+          // Prepare Jira issue data
+          const projectKey = args.projectKey || defaultProjectKey;
+          const issueType = args.issueType || defaultIssueType;
+          const summary = args.summary || `${frame.name} - Figma Design`;
+          
+          let description = `**Figma Frame Details**\n`;
+          description += `- **Frame Name:** ${frame.name}\n`;
+          description += `- **Frame Type:** ${frame.type}\n`;
+          description += `- **Frame ID:** ${frame.id}\n`;
+          description += `- **File ID:** ${args.fileId}\n`;
+          description += `- **Figma Link:** https://www.figma.com/file/${args.fileId}?node-id=${args.frameId}\n\n`;
+          
+          if (frame.comment && frame.comment.length > 0) {
+            description += `**Design Comments:**\n`;
+            frame.comment.forEach((comment, index) => {
+              const status = comment.resolved_at ? '✅ Resolved' : '💬 Open';
+              description += `${index + 1}. ${status} by @${comment.user.handle}\n`;
+              description += `   ${comment.text}\n\n`;
+            });
+          }
+          
+          if (args.description) {
+            description += `**Additional Notes:**\n${args.description}\n\n`;
+          }
+          
+          // Create Jira issue
+          const jiraUrl = `${jiraBaseUrl}/rest/api/3/issue`;
+          const auth = Buffer.from(`${jiraEmail}:${jiraApiToken}`).toString('base64');
+          
+          const jiraBody: JiraCreateIssueRequest = {
+            fields: {
+              project: { key: projectKey },
+              summary,
+              description: {
+                type: 'doc',
+                version: 1,
+                content: [
+                  {
+                    type: 'paragraph',
+                    content: [
+                      {
+                        type: 'text',
+                        text: description
+                      }
+                    ]
+                  }
+                ]
+              },
+              issuetype: { name: issueType }
+            }
+          };
+          
+          const jiraResponse = await fetch(jiraUrl, {
+            method: 'POST',
+            headers: {
+              'Authorization': `Basic ${auth}`,
+              'Content-Type': 'application/json',
+              'Accept': 'application/json'
+            },
+            body: JSON.stringify(jiraBody)
+          });
+          
+          if (!jiraResponse.ok) {
+            const errorText = await jiraResponse.text();
+            throw new Error(`Jira API error: ${jiraResponse.status} ${jiraResponse.statusText} - ${errorText}`);
+          }
+          
+          const rawJiraResult = await jiraResponse.json();
+          if (!isJiraCreateIssueResponse(rawJiraResult)) {
+            throw new Error('Invalid response format from Jira API');
+          }
+          
+          const jiraResult: JiraCreateIssueResponse = rawJiraResult;
+          
+          const result = {
+            message: 'Jira ticket created successfully from Figma frame',
+            jiraIssue: {
+              id: jiraResult.id,
+              key: jiraResult.key,
+              url: `${jiraBaseUrl}/browse/${jiraResult.key}`,
+              summary,
+              projectKey,
+              issueType
+            },
+            figmaFrame: {
+              name: frame.name,
+              type: frame.type,
+              commentsCount: frame.comment?.length || 0,
+              figmaUrl: `https://www.figma.com/file/${args.fileId}?node-id=${args.frameId}`
+            }
+          };
+          
+          return JSON.stringify(result, null, 2);
+        } catch (error) {
+          return `Failed to create Jira ticket from Figma frame: ${error instanceof Error ? error.message : String(error)}`;
+        }
+      },
+    }),
+
+    GET_FIGMA_FILE_INFO: tool({
+      name: 'figma_jira_get_file_info',
+      description: 'Get basic information about a Figma file including available frames',
+      schema: z.object({
+        fileId: z.string().describe('Figma file ID (from the file URL)'),
+      }),
+      handler: async (args, context) => {
+        try {
+          const { figmaToken } = await context.getCredentials();
+          const url = `https://api.figma.com/v1/files/${args.fileId}`;
+          
+          const response = await fetch(url, {
+            headers: { 'X-Figma-Token': figmaToken }
+          });
+          
+          if (!response.ok) {
+            throw new Error(`Figma API error: ${response.status} ${response.statusText}`);
+          }
+          
+          const rawData = await response.json();
+          if (!isFigmaFileInfo(rawData)) {
+            throw new Error('Invalid response format from Figma API');
+          }
+          
+          const data: FigmaFileInfo = rawData;
+          
+          const result = {
+            fileId: data.key,
+            name: data.name,
+            lastModified: data.lastModified,
+            thumbnailUrl: data.thumbnailUrl,
+            version: data.version,
+            document: {
+              name: data.document.name,
+              type: data.document.type,
+              childrenCount: data.document.children?.length || 0
+            }
+          };
+          
+          return JSON.stringify(result, null, 2);
+        } catch (error) {
+          return `Failed to get Figma file info: ${error instanceof Error ? error.message : String(error)}`;
+        }
+      },
+    }),
+
+    SEARCH_FIGMA_FRAMES: tool({
+      name: 'figma_jira_search_frames',
+      description: 'Search for frames within a Figma file by name or type',
+      schema: z.object({
+        fileId: z.string().describe('Figma file ID (from the file URL)'),
+        query: z.string().describe('Search query for frame names or types'),
+        maxResults: z.number().optional().describe('Maximum number of results to return (default: 10)'),
+      }),
+      handler: async (args, context) => {
+        try {
+          const { figmaToken } = await context.getCredentials();
+          const url = `https://api.figma.com/v1/files/${args.fileId}`;
+          
+          const response = await fetch(url, {
+            headers: { 'X-Figma-Token': figmaToken }
+          });
+          
+          if (!response.ok) {
+            throw new Error(`Figma API error: ${response.status} ${response.statusText}`);
+          }
+          
+          const rawData = await response.json();
+          if (!isFigmaFileInfo(rawData)) {
+            throw new Error('Invalid response format from Figma API');
+          }
+          
+          const data: FigmaFileInfo = rawData;
+          const maxResults = args.maxResults || 10;
+          
+          // Recursively search for frames
+          const searchFrames = (nodes: FigmaNode[], query: string): Array<{
+            id: string;
+            name: string;
+            type: string;
+            childrenCount: number;
+          }> => {
+            const results: Array<{
+              id: string;
+              name: string;
+              type: string;
+              childrenCount: number;
+            }> = [];
+            
+            for (const node of nodes) {
+              if (node.type === 'FRAME' && 
+                  (node.name.toLowerCase().includes(query.toLowerCase()) || 
+                   node.type.toLowerCase().includes(query.toLowerCase()))) {
+                results.push({
+                  id: node.id,
+                  name: node.name,
+                  type: node.type,
+                  childrenCount: node.children?.length || 0
+                });
+              }
+              
+              if (node.children && results.length < maxResults) {
+                results.push(...searchFrames(node.children, query));
+              }
+              
+              if (results.length >= maxResults) break;
+            }
+            
+            return results.slice(0, maxResults);
+          };
+          
+          const frames = searchFrames([data.document as FigmaNode], args.query);
+          
+          const result = {
+            fileId: data.key,
+            fileName: data.name,
+            searchQuery: args.query,
+            framesFound: frames.length,
+            frames: frames
+          };
+          
+          return JSON.stringify(result, null, 2);
+        } catch (error) {
+          return `Failed to search Figma frames: ${error instanceof Error ? error.message : String(error)}`;
+        }
+      },
+    }),
+  }),
+});

--- a/packages/mcp-connectors/src/index.ts
+++ b/packages/mcp-connectors/src/index.ts
@@ -12,6 +12,7 @@ import { DuckDuckGoConnectorConfig } from './connectors/duckduckgo';
 import { ElevenLabsConnectorConfig } from './connectors/elevenlabs';
 import { ExaConnectorConfig } from './connectors/exa';
 import { FalConnectorConfig } from './connectors/fal';
+import { FigmaJiraConnectorConfig } from './connectors/figma_jira';
 import { FirefliesConnectorConfig } from './connectors/fireflies';
 import { GitHubConnectorConfig } from './connectors/github';
 import { GoogleDriveConnectorConfig } from './connectors/google-drive';
@@ -55,6 +56,7 @@ export const Connectors: readonly MCPConnectorConfig[] = [
   ElevenLabsConnectorConfig,
   ExaConnectorConfig,
   FalConnectorConfig,
+  FigmaJiraConnectorConfig,
   GitHubConnectorConfig,
   GoogleDriveConnectorConfig,
   HiBobConnectorConfig,
@@ -97,6 +99,7 @@ export {
   ElevenLabsConnectorConfig,
   ExaConnectorConfig,
   FalConnectorConfig,
+  FigmaJiraConnectorConfig,
   GitHubConnectorConfig,
   GoogleDriveConnectorConfig,
   HiBobConnectorConfig,


### PR DESCRIPTION
🎨🔗 Figma-Jira MCP Connector

Tired of copy-pasting design screenshots into Jira tickets?
We built the Figma-Jira MCP Connector — a bridge between design and development that makes your workflow smooth, smart, and fun.

✨ Why It’s Cool

Designs → Tickets in 1 click: Turn Figma frames into Jira issues instantly (with all the context included).

No more lost comments: Pull in Figma feedback so devs don’t miss critical details.

Smart frame search: Find exactly the design frame you need without scrolling for hours.

Workflow magic: Automate bug reports, feature requests, and design system updates.

Traceability FTW: Keep a clear line from design iterations → development tasks → shipped product.

🚀 How It Works

Grab design data from Figma (frames, comments, metadata).

Push it to Jira with all the juicy details.

Search & discover frames in seconds.

Automate the boring stuff like bug reporting or design handoffs.

🛠️ Quick Demo
# Start the connector
bun run start -- --connector figma_jira \
  --credentials '{ "figmaToken": "xxx", "jiraEmail": "xxx", "jiraApiToken": "xxx", "jiraBaseUrl": "https://yourcompany.atlassian.net" }' \
  --setup '{ "defaultProjectKey": "PROJ", "defaultIssueType": "Task" }'


Then:

Run figma_jira_get_frame → Boom, design data.

Run figma_jira_create_ticket_from_frame → Boom, Jira ticket with design context.

🧩 Example Use Cases

🐛 Design Review → Bug Report: Capture Figma comments → auto-Jira bug.

🚀 Feature Request: Product team designs → auto-story in Jira.

🎨 Design System Update: Documented in Figma → task created in Jira.

🏆 Why We Built This for the Hackathon

Because designers & devs speak different languages — we’re the translator.

Because no one likes manual handoffs (they break things).

Because automation should feel like magic 🪄.

Because MCP makes it possible to connect these worlds in a lightweight, extensible way.

💡 The Vibe

Think of it as:
“What if Figma and Jira had a baby… and it actually made teamwork fun?” 😎

🔥 Built for the hackathon.
⚡ Powered by MCP.
❤️ Loved by designers and developers.
    
<!-- This is an auto-generated description by cubic. -->
---

## Summary by cubic
Adds a Figma–Jira MCP connector to create Jira issues from Figma frames and to fetch/search Figma data. Registers the connector and adds basic tests.

- **New Features**
  - New connector (key: figma_jira) with credentials: figmaToken, jiraEmail, jiraApiToken, jiraBaseUrl; setup: defaultProjectKey, defaultIssueType.
  - Tools: figma_jira_get_frame, figma_jira_create_ticket_from_frame, figma_jira_get_file_info, figma_jira_search_frames.
  - Jira tickets include frame metadata, comments, and a Figma link; supports default/override project and issue type; clear error handling.

- **Migration**
  - Provide required credentials and setup values in the connector config.
  - Use defaults or pass projectKey/issueType when creating tickets.

<!-- End of auto-generated description by cubic. -->

