### PR TITLE
feat: add topcashback and quidco connectors (team 3)

### DIFF
--- a/docs/quidco-topcashback-cashback-mcp.md
+++ b/docs/quidco-topcashback-cashback-mcp.md
@@ -1,0 +1,175 @@
+# Quidco & TopCashback MCP Connectors
+
+## 1. Problem Statement (PR Summary Narrative)
+When shopping online (eBay, AliExpress, etc.) I want the best cashback rate. Today I must:
+1. Log into Quidco.
+2. Search the merchant.
+3. Log into TopCashback.
+4. Search again.
+5. (Potentially) Log into Rakuten.
+6. Manually compare, then click the winning affiliate link.
+
+This is repetitive, slow, and error‑prone (easy to miss rate changes or promo spikes). We want MCP connectors so any agent or automation can quickly fetch current rates from multiple sources, pick the best, and open the correct deep link.
+
+## 2. Current Implementation Scope
+Two MCP connectors implemented:
+
+| Connector | Tools | Purpose |
+|-----------|-------|---------|
+| TopCashback | `topcashback_login`, `topcashback_search_merchants`, `topcashback_get_cashback_rate`, `topcashback_get_cashback_rate_best_match` | Auth, merchant autocomplete, rate extraction, best-match + normalization. |
+| Quidco | `quidco_login`, `quidco_get_user`, `quidco_search_merchants`, `quidco_get_cashback_offer`, `quidco_get_cashback_offer_best_match` | Auth, user header data, merchant suggestions, offer extraction, best-match + normalization. |
+
+### Normalization
+Both connectors parse all percentage tokens (e.g. "Up to 5% cashback" → percentages=[5], min=5, max=5). Ranges (e.g. "2% - 8%") become min=2, max=8, range=true.
+
+### Best-Match Heuristic
+Scoring: exact match > prefix > substring > character overlap. Chosen for speed + determinism during prototyping; can be upgraded later (e.g. Levenshtein / token-based similarity).
+
+### Session Handling
+Simple cookie capture stored via cache keys: `topcashback:session`, `quidco:session`.
+
+## 3. Architecture Overview
+```
+apps/server (generic MCP HTTP host)
+packages/mcp-connectors
+	└─ src/connectors/
+			 topcashback.ts
+			 quidco.ts
+			 ... (other connectors)
+```
+Each connector exports an `mcpConnectorConfig`. The server process loads configs and exposes tools over JSON-RPC (HTTP + text/event-stream).
+
+## 4. Usage (Local Testing)
+### Start Servers (distinct ports)
+```bash
+bun run build
+
+# Terminal 1
+bun run apps/server/src/index.ts --port 3001 --connector topcashback
+
+# Terminal 2
+bun run apps/server/src/index.ts --port 3002 --connector quidco
+```
+
+### List Tools
+```bash
+curl -s -X POST http://localhost:3001/mcp \
+	-H 'Content-Type: application/json' -H 'Accept: application/json, text/event-stream' \
+	-d '{"jsonrpc":"2.0","id":"list","method":"tools/list","params":{}}'
+```
+
+### Login (Inline Credentials)
+```bash
+curl -s -X POST http://localhost:3001/mcp \
+	-H 'Content-Type: application/json' -H 'Accept: application/json, text/event-stream' \
+	-d '{"jsonrpc":"2.0","id":"login","method":"tools/call","params":{"name":"topcashback_login","arguments":{"email":"you@example.com","password":"secret"}}}'
+```
+
+### Best Match Rate
+```bash
+curl -s -X POST http://localhost:3001/mcp \
+	-H 'Content-Type: application/json' -H 'Accept: application/json, text/event-stream' \
+	-d '{"jsonrpc":"2.0","id":"best","method":"tools/call","params":{"name":"topcashback_get_cashback_rate_best_match","arguments":{"query":"ebay"}}}'
+```
+
+### Quidco Offer (Best Match)
+```bash
+curl -s -X POST http://localhost:3002/mcp \
+	-H 'Content-Type: application/json' -H 'Accept: application/json, text/event-stream' \
+	-d '{"jsonrpc":"2.0","id":"best","method":"tools/call","params":{"name":"quidco_get_cashback_offer_best_match","arguments":{"query":"ebay"}}}'
+```
+
+## 5. Agent / Copilot Workflow
+1. Ensure `.mcp.json` lists both servers with correct ports & Accept header.
+2. Reload editor so MCP clients re-scan.
+3. In chat: "Login to TopCashback then fetch the best cashback rate for Adidas; do the same with Quidco and compare."
+4. The agent sequentially invokes the login + best-match tools and summarizes normalized outputs.
+
+## 7. Money-Saving Automation Strategy
+| Step | Action | Tool(s) | Notes |
+|------|--------|---------|-------|
+| 1 | Normalize merchant name | (client-side) | Pre-clean input. |
+| 2 | Fetch rates concurrently | `*_get_cashback_rate_best_match` / `*_get_cashback_offer_best_match` | Parallel RPC. |
+| 3 | Parse normalized fields | Already returned | Compare maxPercentage values. |
+| 4 | Select winning site | Decision function | Add tie-break (historical reliability?). |
+| 5 | Construct outbound URL | Future enhancement | Need each site’s affiliate redirect link. |
+| 6 | Open in browser | Client | Confirm cookie path for attribution. |
+
+### Practical Cashback Tips
+- Always click through from the chosen site last (avoid overwriting referral cookies).
+- Disable competing cashback / coupon browser extensions that may hijack the attribution.
+- Document expected vs credited rates to detect tracking failures early.
+- For "Up to" phrasing treat minPercentage as conservative baseline.
+
+## 8. Limitations / Risks
+| Area | Current Approach | Risk | Mitigation Idea |
+|------|------------------|------|-----------------|
+| HTML Selectors | Single CSS span lookup | Site DOM changes | Add fallback patterns + tests. |
+| Heuristic Matching | Simple scoring | Ambiguous matches | Introduce fuzzy distance + threshold. |
+| Sessions | In-memory cookies | Expire mid-session | Auto 401 relogin wrapper. |
+| Rate Semantics | Raw text | Misinterpreting tiered offers | Structured parsing rules per phrase taxonomy. |
+| Scaling | Serial fetch per site | Added latency with more sites | Concurrent & caching layer. |
+
+## 9. Roadmap
+### Near-Term
+- Shared utility module for matching + percentage normalization.
+- Structured JSON output mode (machine-consumable fields separate from human text).
+- Add Rakuten connector; meta-tool: `cashback_compare_best` (queries all sites & returns champion with deltas).
+
+### Mid-Term
+- Persistence layer (encrypted sessions) + refresh logic.
+- Fuzzy matching upgrade (Levenshtein / token Jaccard).
+- Rate-change alerting (diff detection + push via webhook or notification tool).
+
+### Long-Term
+- Affiliate deep link capture to enable one-click redirection.
+- Historical rate datastore for trend / timing recommendations.
+- Confidence scoring (DOM pattern stability, parse quality metrics).
+
+## 10. Testing Strategy Summary
+- Unit + integration via Vitest + MSW (mock network + DOM HTML fixtures).
+- Cases: success, empty list, 401/403 unauthorized, 404/500 failures, missing rate span, normalization correctness, best-match selection.
+- Future: snapshot structured JSON for regression detection.
+
+## 11. PR Summary
+> Adds Quidco & TopCashback MCP connectors providing authenticated merchant search, cashback rate / offer extraction, best-match merchant resolution, and percentage normalization. Introduces optional inline credential arguments with validation. Distinct local ports (3001/3002) for parallel operation. Lays groundwork for a cross-site comparison meta-tool and future Rakuten integration.
+
+**Benefits:** Automatable multi-site cashback comparison; reduced manual tab-hopping; foundation for rate monitoring & affiliate deep linking.
+
+**Not Included Yet:** Rakuten connector, fuzzy string matching, session auto-refresh, structured JSON vs text split, affiliate link opening.
+
+## 12. Future Meta-Tool Concept
+`cashback_compare_best` (planned):
+1. Ensure sessions for all configured cashback connectors.
+2. Parallel best-match queries.
+3. Aggregate normalized results into ranked table.
+4. Return champion + reasoning + (future) action link.
+
+## 13. Contribution Ideas for Hack Participants
+- Add new site connector (Rakuten / Honey Gold / Capital One Shopping).
+- Implement shared `cashback-utils.ts` with normalization + matching.
+- Add fuzzy matcher with configurable strategy.
+- Implement meta comparator tool.
+- Add rate history persistence (SQLite / Tinybird / Supabase).
+
+## 14. Security & Privacy Notes
+- Credentials only used transiently for login; not stored beyond runtime cache.
+- Consider adding secret manager integration if moving to hosted multi-user environment.
+- Avoid logging raw credential values (current code does not log them).
+
+## 15. Open Questions
+| Question | Rationale |
+|----------|-----------|
+| How often do rates change per merchant? | Drives polling frequency & cache TTL. |
+| Are differential tiers (new vs existing customers) distinguishable reliably? | Impacts accuracy of decision logic. |
+| What affiliate link extraction strategy is acceptable (T&C compliance)? | Legal & attribution integrity. |
+
+## 16. Next Steps Checklist
+- [ ] Extract shared helpers
+- [ ] Add Rakuten connector
+- [ ] Implement comparison meta-tool
+- [ ] Add fuzzy matching
+- [ ] Auto re-login on 401
+- [ ] Structured JSON output mode
+- [ ] Affiliate redirect capture
+- [ ] Historical rate storage + alerting

--- a/packages/mcp-connectors/src/connectors/quidco.spec.ts
+++ b/packages/mcp-connectors/src/connectors/quidco.spec.ts
@@ -1,0 +1,339 @@
+import type { MCPToolDefinition } from "@stackone/mcp-config-types";
+import { http, HttpResponse } from "msw";
+import { setupServer } from "msw/node";
+import { describe, expect, it, vi } from "vitest";
+import { createMockConnectorContext } from "../__mocks__/context";
+import { QuidcoConnectorConfig } from "./quidco";
+
+describe("#QuidcoConnectorConfig", () => {
+  describe(".LOGIN", () => {
+    describe("when credentials are valid", () => {
+      it("returns success and caches session", async () => {
+        const server = setupServer(
+          http.post("https://identity-cognito.quidco.com/", () => {
+            return new HttpResponse(JSON.stringify({ ok: true }), {
+              status: 200,
+              headers: { "Set-Cookie": "SessionId=quidco123; Path=/;" },
+            });
+          })
+        );
+        server.listen();
+        const tool = QuidcoConnectorConfig.tools.LOGIN as MCPToolDefinition;
+        const mockContext = createMockConnectorContext();
+        (
+          mockContext.getCredentials as ReturnType<typeof vi.fn>
+        ).mockResolvedValue({
+          email: "user@example.com",
+          password: "pass",
+        });
+        const actual = await tool.handler({}, mockContext);
+        server.close();
+        expect(actual).toContain("Login successful");
+        expect(mockContext.writeCache).toHaveBeenCalled();
+      });
+    });
+    describe("when credentials are invalid", () => {
+      it("returns failure message", async () => {
+        const server = setupServer(
+          http.post("https://identity-cognito.quidco.com/", () => {
+            return new HttpResponse("Unauthorized", { status: 401 });
+          })
+        );
+        server.listen();
+        const tool = QuidcoConnectorConfig.tools.LOGIN as MCPToolDefinition;
+        const mockContext = createMockConnectorContext();
+        (
+          mockContext.getCredentials as ReturnType<typeof vi.fn>
+        ).mockResolvedValue({
+          email: "bad@example.com",
+          password: "wrong",
+        });
+        const actual = await tool.handler({}, mockContext);
+        server.close();
+        expect(actual).toContain("Login failed");
+        expect(actual).toContain("Invalid credentials");
+      });
+    });
+  });
+
+  describe(".GET_USER", () => {
+    describe("when session is valid", () => {
+      it("returns user data JSON", async () => {
+        const server = setupServer(
+          http.get("https://www.quidco.com/ajax/user/user_header_data", () => {
+            return HttpResponse.json({
+              user_id: 1,
+              first_name: "Alice",
+              user_type: 4,
+              total_earned: 10.5,
+              total_tracked: 2.3,
+              payable_cashback: 1.1,
+            });
+          })
+        );
+        server.listen();
+        const tool = QuidcoConnectorConfig.tools.GET_USER as MCPToolDefinition;
+        const mockContext = createMockConnectorContext();
+        (mockContext.readCache as ReturnType<typeof vi.fn>).mockResolvedValue({
+          value: { cookies: "SessionId=quidco123" },
+        });
+        const actual = await tool.handler({}, mockContext);
+        server.close();
+        expect(actual).toContain("Alice");
+        expect(actual).toContain("totalEarned");
+      });
+    });
+    describe("when session missing", () => {
+      it("instructs to login", async () => {
+        const tool = QuidcoConnectorConfig.tools.GET_USER as MCPToolDefinition;
+        const mockContext = createMockConnectorContext();
+        (mockContext.readCache as ReturnType<typeof vi.fn>).mockResolvedValue(
+          null
+        );
+        const actual = await tool.handler({}, mockContext);
+        expect(actual).toContain("login first");
+      });
+    });
+    describe("when unauthorized", () => {
+      it("returns error message", async () => {
+        const server = setupServer(
+          http.get("https://www.quidco.com/ajax/user/user_header_data", () => {
+            return new HttpResponse("Forbidden", { status: 403 });
+          })
+        );
+        server.listen();
+        const tool = QuidcoConnectorConfig.tools.GET_USER as MCPToolDefinition;
+        const mockContext = createMockConnectorContext();
+        (mockContext.readCache as ReturnType<typeof vi.fn>).mockResolvedValue({
+          value: { cookies: "SessionId=quidco123" },
+        });
+        const actual = await tool.handler({}, mockContext);
+        server.close();
+        expect(actual).toContain("Failed to fetch user");
+        expect(actual).toContain("Unauthorized");
+      });
+    });
+  });
+
+  describe(".SEARCH_MERCHANTS", () => {
+    describe("when session is valid", () => {
+      it("returns suggestions list", async () => {
+        const server = setupServer(
+          http.get(
+            "https://www.quidco.com/ajax/search/suggestions",
+            ({ request }) => {
+              const url = new URL(request.url);
+              if (url.searchParams.get("search_term") === "ebay") {
+                return HttpResponse.json({
+                  suggestions: [{ id: "1", name: "EBay" }],
+                });
+              }
+              return HttpResponse.json({ suggestions: [] });
+            }
+          )
+        );
+        server.listen();
+        const tool = QuidcoConnectorConfig.tools
+          .SEARCH_MERCHANTS as MCPToolDefinition;
+        const mockContext = createMockConnectorContext();
+        (mockContext.readCache as ReturnType<typeof vi.fn>).mockResolvedValue({
+          value: { cookies: "SessionId=quidco123" },
+        });
+        const actual = await tool.handler({ query: "ebay" }, mockContext);
+        server.close();
+        expect(actual).toContain("EBay");
+      });
+    });
+    describe("when no results", () => {
+      it("returns no merchants found", async () => {
+        const server = setupServer(
+          http.get("https://www.quidco.com/ajax/search/suggestions", () => {
+            return HttpResponse.json({ suggestions: [] });
+          })
+        );
+        server.listen();
+        const tool = QuidcoConnectorConfig.tools
+          .SEARCH_MERCHANTS as MCPToolDefinition;
+        const mockContext = createMockConnectorContext();
+        (mockContext.readCache as ReturnType<typeof vi.fn>).mockResolvedValue({
+          value: { cookies: "SessionId=quidco123" },
+        });
+        const actual = await tool.handler({ query: "zzz" }, mockContext);
+        server.close();
+        expect(actual).toContain("No merchants found");
+      });
+    });
+    describe("when session missing", () => {
+      it("instructs to login first", async () => {
+        const tool = QuidcoConnectorConfig.tools
+          .SEARCH_MERCHANTS as MCPToolDefinition;
+        const mockContext = createMockConnectorContext();
+        (mockContext.readCache as ReturnType<typeof vi.fn>).mockResolvedValue(
+          null
+        );
+        const actual = await tool.handler({ query: "ebay" }, mockContext);
+        expect(actual).toContain("login first");
+      });
+    });
+    describe("when API returns error", () => {
+      it("returns error message", async () => {
+        const server = setupServer(
+          http.get("https://www.quidco.com/ajax/search/suggestions", () => {
+            return new HttpResponse("Server error", { status: 500 });
+          })
+        );
+        server.listen();
+        const tool = QuidcoConnectorConfig.tools
+          .SEARCH_MERCHANTS as MCPToolDefinition;
+        const mockContext = createMockConnectorContext();
+        (mockContext.readCache as ReturnType<typeof vi.fn>).mockResolvedValue({
+          value: { cookies: "SessionId=quidco123" },
+        });
+        const actual = await tool.handler({ query: "ebay" }, mockContext);
+        server.close();
+        expect(actual).toContain("Merchant search failed");
+        expect(actual).toContain("500");
+      });
+    });
+  });
+
+  describe(".GET_CASHBACK_OFFER", () => {
+    describe("when offer exists", () => {
+      it("returns formatted offer", async () => {
+        const server = setupServer(
+          http.get("https://www.quidco.com/ebay/", () => {
+            return HttpResponse.text(
+              '<html><span class="offer-value">5% cashback</span></html>'
+            );
+          })
+        );
+        server.listen();
+        const tool = QuidcoConnectorConfig.tools
+          .GET_CASHBACK_OFFER as MCPToolDefinition;
+        const mockContext = createMockConnectorContext();
+        (mockContext.readCache as ReturnType<typeof vi.fn>).mockResolvedValue({
+          value: { cookies: "SessionId=quidco123" },
+        });
+        const actual = await tool.handler(
+          { merchantSlug: "ebay" },
+          mockContext
+        );
+        server.close();
+        expect(actual).toContain("Offer: 5% cashback");
+        expect(actual).toContain("Normalized");
+      });
+    });
+    describe("when offer missing", () => {
+      it("returns not found message", async () => {
+        const server = setupServer(
+          http.get("https://www.quidco.com/unknown/", () => {
+            return HttpResponse.text("<html><body>No offer</body></html>");
+          })
+        );
+        server.listen();
+        const tool = QuidcoConnectorConfig.tools
+          .GET_CASHBACK_OFFER as MCPToolDefinition;
+        const mockContext = createMockConnectorContext();
+        (mockContext.readCache as ReturnType<typeof vi.fn>).mockResolvedValue({
+          value: { cookies: "SessionId=quidco123" },
+        });
+        const actual = await tool.handler(
+          { merchantSlug: "unknown" },
+          mockContext
+        );
+        server.close();
+        expect(actual).toContain("Offer value not found");
+      });
+    });
+    describe("when fetch fails", () => {
+      it("returns error message with status", async () => {
+        const server = setupServer(
+          http.get("https://www.quidco.com/failing/", () => {
+            return new HttpResponse("Not Found", { status: 404 });
+          })
+        );
+        server.listen();
+        const tool = QuidcoConnectorConfig.tools
+          .GET_CASHBACK_OFFER as MCPToolDefinition;
+        const mockContext = createMockConnectorContext();
+        (mockContext.readCache as ReturnType<typeof vi.fn>).mockResolvedValue({
+          value: { cookies: "SessionId=quidco123" },
+        });
+        const actual = await tool.handler(
+          { merchantSlug: "failing" },
+          mockContext
+        );
+        server.close();
+        expect(actual).toContain("Failed to get cashback offer");
+        expect(actual).toContain("404");
+      });
+    });
+  });
+
+  describe(".GET_CASHBACK_OFFER_BEST_MATCH", () => {
+    describe("when suggestions and offer exist", () => {
+      it("returns best match with normalized output", async () => {
+        const server = setupServer(
+          http.get("https://www.quidco.com/ajax/search/suggestions", () => {
+            return HttpResponse.json({
+              suggestions: [
+                { id: "1", name: "EBay" },
+                { id: "2", name: "Ebuyer" },
+              ],
+            });
+          }),
+          http.get("https://www.quidco.com/ebay/", () => {
+            return HttpResponse.text(
+              '<html><span class="offer-value">Up to 6% cashback</span></html>'
+            );
+          })
+        );
+        server.listen();
+        const tool = QuidcoConnectorConfig.tools
+          .GET_CASHBACK_OFFER_BEST_MATCH as MCPToolDefinition;
+        const mockContext = createMockConnectorContext();
+        (mockContext.readCache as ReturnType<typeof vi.fn>).mockImplementation(
+          async (key) =>
+            key === "quidco:session" ? "SessionId=quidco123" : null
+        );
+        const actual = await tool.handler({ query: "ebay" }, mockContext);
+        server.close();
+        expect(actual).toContain("Best Match: EBay");
+        expect(actual).toContain("Normalized");
+        expect(actual).toContain("6%");
+      });
+    });
+    describe("when no session", () => {
+      it("asks to login", async () => {
+        const tool = QuidcoConnectorConfig.tools
+          .GET_CASHBACK_OFFER_BEST_MATCH as MCPToolDefinition;
+        const mockContext = createMockConnectorContext();
+        (mockContext.readCache as ReturnType<typeof vi.fn>).mockImplementation(
+          async () => null
+        );
+        const actual = await tool.handler({ query: "ebay" }, mockContext);
+        expect(actual).toContain("login first");
+      });
+    });
+    describe("when no merchants found", () => {
+      it("returns no merchants message", async () => {
+        const server = setupServer(
+          http.get("https://www.quidco.com/ajax/search/suggestions", () => {
+            return HttpResponse.json({ suggestions: [] });
+          })
+        );
+        server.listen();
+        const tool = QuidcoConnectorConfig.tools
+          .GET_CASHBACK_OFFER_BEST_MATCH as MCPToolDefinition;
+        const mockContext = createMockConnectorContext();
+        (mockContext.readCache as ReturnType<typeof vi.fn>).mockImplementation(
+          async (key) =>
+            key === "quidco:session" ? "SessionId=quidco123" : null
+        );
+        const actual = await tool.handler({ query: "zzz" }, mockContext);
+        server.close();
+        expect(actual).toContain("No merchants found");
+      });
+    });
+  });
+});

--- a/packages/mcp-connectors/src/connectors/quidco.ts
+++ b/packages/mcp-connectors/src/connectors/quidco.ts
@@ -1,0 +1,335 @@
+import { mcpConnectorConfig } from "@stackone/mcp-config-types";
+import { parse as parseHTML } from "node-html-parser";
+import { z } from "zod";
+
+// Simple cookie extraction helper
+function extractCookies(setCookieHeaders: string[]): string {
+  const pairs: string[] = [];
+  for (const header of setCookieHeaders) {
+    const first = header.split(";")[0];
+    if (first) pairs.push(first.trim());
+  }
+  const map = new Map<string, string>();
+  for (const p of pairs) {
+    const [k, ...rest] = p.split("=");
+    if (k) map.set(k, `${k}=${rest.join("=")}`);
+  }
+  return Array.from(map.values()).join("; ");
+}
+
+interface QuidcoUserHeaderData {
+  user_id: number;
+  first_name: string;
+  user_type: number;
+  total_earned: number;
+  total_tracked: number;
+  payable_cashback: number;
+}
+
+async function performLogin(
+  email: string,
+  password: string
+): Promise<{ cookies: string }> {
+  // Quidco seems to authenticate via an identity endpoint; we simulate a basic credential POST
+  const LOGIN_URL = "https://identity-cognito.quidco.com/";
+  const body = JSON.stringify({ email, password });
+  const resp = await fetch(LOGIN_URL, {
+    method: "POST",
+    headers: {
+      "Content-Type": "application/json",
+      "User-Agent": "Mozilla/5.0 MCP Quidco Connector",
+      Accept: "application/json, text/plain, */*",
+    },
+    body,
+  });
+  if (resp.status === 401) throw new Error("Invalid credentials (401)");
+  if (!resp.ok) throw new Error(`Login failed: ${resp.status}`);
+  const cookies = extractCookies(
+    resp.headers.getSetCookie ? resp.headers.getSetCookie() : []
+  );
+  if (!cookies) throw new Error("No session cookies returned");
+  return { cookies };
+}
+
+async function fetchUserHeader(cookies: string): Promise<QuidcoUserHeaderData> {
+  const url = "https://www.quidco.com/ajax/user/user_header_data";
+  const resp = await fetch(url, {
+    headers: {
+      Accept: "application/json, text/plain, */*",
+      Cookie: cookies,
+      Referer: "https://www.quidco.com/home/",
+      "User-Agent": "Mozilla/5.0 MCP Quidco Connector",
+    },
+  });
+  if (resp.status === 401 || resp.status === 403) {
+    throw new Error("Unauthorized – login required");
+  }
+  if (!resp.ok) throw new Error(`Failed to fetch user header: ${resp.status}`);
+  return (await resp.json()) as QuidcoUserHeaderData;
+}
+
+async function searchMerchants(
+  query: string,
+  cookies: string
+): Promise<{ id: string; name: string }[]> {
+  const url = `https://www.quidco.com/ajax/search/suggestions?search_term=${encodeURIComponent(
+    query
+  )}`;
+  const resp = await fetch(url, {
+    headers: {
+      Accept: "application/json, text/plain, */*",
+      Cookie: cookies,
+      Referer: "https://www.quidco.com/home/",
+      "User-Agent": "Mozilla/5.0 MCP Quidco Connector",
+    },
+  });
+  if (resp.status === 401 || resp.status === 403)
+    throw new Error("Unauthorized – login required");
+  if (!resp.ok) throw new Error(`Search failed: ${resp.status}`);
+  const data = (await resp.json()) as {
+    suggestions?: Array<{ id: string; name: string }>;
+  };
+  return data.suggestions ?? [];
+}
+
+async function fetchCashbackOffer(
+  slug: string,
+  cookies?: string
+): Promise<string | null> {
+  const url = `https://www.quidco.com/${slug.replace(/[^a-z0-9-]/gi, "")}/`;
+  const resp = await fetch(url, {
+    headers: {
+      "User-Agent": "Mozilla/5.0 MCP Quidco Connector",
+      Accept: "text/html,application/xhtml+xml,application/xml;q=0.9,*/*;q=0.8",
+      ...(cookies ? { Cookie: cookies } : {}),
+    },
+  });
+  if (!resp.ok)
+    throw new Error(`Failed to fetch merchant page (${resp.status})`);
+  const html = await resp.text();
+  const root = parseHTML(html);
+  const span = root.querySelector(".offer-value");
+  if (!span) return null;
+  return span.text.trim().replace(/\s+/g, " ");
+}
+
+export const QuidcoConnectorConfig = mcpConnectorConfig({
+  name: "Quidco",
+  key: "quidco",
+  version: "1.0.0",
+  logo: "https://stackone-logos.com/api/quidco/filled/svg",
+  credentials: z.object({
+    email: z.string().describe("Your Quidco account email"),
+    password: z.string().describe("Your Quidco account password"),
+  }),
+  setup: z.object({}),
+  examplePrompt:
+    'Login to Quidco, show my total earned cashback, search for "eBay" and return the best current cashback offer.',
+  tools: (tool) => ({
+    LOGIN: tool({
+      name: "quidco_login",
+      description:
+        "Authenticate with Quidco and cache a session. Provide email/password args or have stored credentials.",
+      schema: z.object({
+        email: z
+          .string()
+          .optional()
+          .describe("Quidco account email (optional if stored credentials configured)"),
+        password: z
+          .string()
+          .optional()
+          .describe("Quidco account password (optional if stored credentials configured)"),
+      }),
+      handler: async (args, context) => {
+        try {
+          let stored: any = {};
+          try {
+            stored = (await context.getCredentials()) || {};
+          } catch {
+            // ignore
+          }
+          const email = (args.email || stored.email) as string | undefined;
+          const password = (args.password || stored.password) as
+            | string
+            | undefined;
+          if (!email || !password) {
+            return "Missing credentials: supply email/password arguments or configure stored credentials.";
+          }
+          const session = await performLogin(email, password);
+          await context.writeCache("quidco:session", session.cookies);
+          return "Login successful";
+        } catch (e) {
+          return `Login failed: ${e instanceof Error ? e.message : String(e)}`;
+        }
+      },
+    }),
+    GET_USER: tool({
+      name: "quidco_get_user",
+      description:
+        "Return basic Quidco user header data (earnings, tracked, payable) to verify login",
+      schema: z.object({}),
+      handler: async (_args, context) => {
+        try {
+          const cookies = (await context.readCache("quidco:session")) as
+            | string
+            | null;
+          if (!cookies) return "No active session found. Please login first.";
+          const user = await fetchUserHeader(cookies);
+          return JSON.stringify(
+            {
+              id: user.user_id,
+              firstName: user.first_name,
+              totalEarned: user.total_earned,
+              totalTracked: user.total_tracked,
+              payableCashback: user.payable_cashback,
+            },
+            null,
+            2
+          );
+        } catch (e) {
+          return `Failed to fetch user: ${
+            e instanceof Error ? e.message : String(e)
+          }`;
+        }
+      },
+    }),
+    SEARCH_MERCHANTS: tool({
+      name: "quidco_search_merchants",
+      description:
+        "Search for merchants by name using Quidco suggestions (requires login)",
+      schema: z.object({
+        query: z.string().describe("Merchant search query fragment"),
+      }),
+      handler: async (args, context) => {
+        try {
+          const cookies = (await context.readCache("quidco:session")) as
+            | string
+            | null;
+          if (!cookies) return "No active session found. Please login first.";
+          const suggestions = await searchMerchants(args.query, cookies);
+          if (suggestions.length === 0) return "No merchants found";
+          return suggestions.map((s) => `${s.id}\t${s.name}`).join("\n");
+        } catch (e) {
+          return `Merchant search failed: ${
+            e instanceof Error ? e.message : String(e)
+          }`;
+        }
+      },
+    }),
+    GET_CASHBACK_OFFER: tool({
+      name: "quidco_get_cashback_offer",
+      description:
+        "Fetch the displayed cashback offer value (span.offer-value) for a merchant slug",
+      schema: z.object({
+        merchantSlug: z
+          .string()
+          .describe(
+            'Merchant slug as in URL, e.g. "ebay" for https://www.quidco.com/ebay/'
+          ),
+      }),
+      handler: async (args, context) => {
+        try {
+          const cookies = (await context.readCache("quidco:session")) as
+            | string
+            | null;
+          const offer = await fetchCashbackOffer(
+            args.merchantSlug,
+            cookies === null ? undefined : cookies
+          );
+          if (!offer) return "Offer value not found";
+          const normalized = normalizePercentage(offer);
+          return `Merchant: ${
+            args.merchantSlug
+          }\nOffer: ${offer}\nNormalized: ${JSON.stringify(normalized)}`;
+        } catch (e) {
+          return `Failed to get cashback offer: ${
+            e instanceof Error ? e.message : String(e)
+          }`;
+        }
+      },
+    }),
+    GET_CASHBACK_OFFER_BEST_MATCH: tool({
+      name: "quidco_get_cashback_offer_best_match",
+      description:
+        "Search merchants, choose best match for query, then fetch and normalize its cashback offer",
+      schema: z.object({
+        query: z.string().describe("Merchant name query"),
+      }),
+      handler: async (args, context) => {
+        try {
+          const cookies = (await context.readCache("quidco:session")) as
+            | string
+            | null;
+          if (!cookies) return "No active session found. Please login first.";
+          const suggestions = await searchMerchants(args.query, cookies);
+          if (suggestions.length === 0) return "No merchants found";
+          const best = pickBestMatch(
+            args.query,
+            suggestions.map((s) => s.name)
+          );
+          if (!best) return "Unable to determine best match";
+          const slug = best.toLowerCase();
+          const offer = await fetchCashbackOffer(slug, cookies);
+          if (!offer) return `Best match '${best}' found but offer not present`;
+          const normalized = normalizePercentage(offer);
+          return `Best Match: ${best}\nSlug: ${slug}\nOffer: ${offer}\nNormalized: ${JSON.stringify(
+            normalized
+          )}`;
+        } catch (e) {
+          return `Failed to get best match cashback offer: ${
+            e instanceof Error ? e.message : String(e)
+          }`;
+        }
+      },
+    }),
+  }),
+});
+
+// --- Helpers (kept local to this file) ---
+function scoreCandidate(query: string, candidate: string): number {
+  const q = query.toLowerCase();
+  const c = candidate.toLowerCase();
+  if (q === c) return 100;
+  if (c.startsWith(q)) return 80;
+  if (c.includes(q)) return 60;
+  let overlap = 0;
+  for (const ch of new Set(q.split(""))) if (c.includes(ch)) overlap++;
+  return overlap;
+}
+function pickBestMatch(query: string, candidates: string[]): string | null {
+  let best: string | null = null;
+  let bestScore = -1;
+  for (const c of candidates) {
+    const s = scoreCandidate(query, c);
+    if (s > bestScore) {
+      bestScore = s;
+      best = c;
+    }
+  }
+  return best;
+}
+interface NormalizedPercentageInfo {
+  raw: string;
+  percentages: number[];
+  minPercentage: number | null;
+  maxPercentage: number | null;
+  range: boolean;
+}
+function normalizePercentage(rawInput: string): NormalizedPercentageInfo {
+  const raw = String(rawInput);
+  const percentMatches = Array.from(raw.matchAll(/(\d+(?:\.\d+)?)\s*%/g)).map(
+    (m) => parseFloat(m[1] as string)
+  );
+  const percentages = percentMatches.sort((a, b) => a - b);
+  const min: number | null = percentages.length ? percentages[0]! : null;
+  const max: number | null = percentages.length
+    ? percentages[percentages.length - 1]!
+    : null;
+  return {
+    raw,
+    percentages,
+    minPercentage: min,
+    maxPercentage: max,
+    range: !!(min !== null && max !== null && min !== max),
+  };
+}

--- a/packages/mcp-connectors/src/connectors/topcashback.spec.ts
+++ b/packages/mcp-connectors/src/connectors/topcashback.spec.ts
@@ -1,0 +1,321 @@
+import type { MCPToolDefinition } from "@stackone/mcp-config-types";
+import { http, HttpResponse } from "msw";
+import { setupServer } from "msw/node";
+import { describe, expect, it, vi } from "vitest";
+import { createMockConnectorContext } from "../__mocks__/context";
+import { TopCashbackConnectorConfig } from "./topcashback";
+
+describe("#TopCashbackConnectorConfig", () => {
+  describe(".LOGIN", () => {
+    describe("when credentials are valid", () => {
+      it("returns success and writes cache", async () => {
+        const server = setupServer(
+          http.get("https://www.topcashback.co.uk/logon/", () => {
+            return new HttpResponse(
+              '<html><input name="__RequestVerificationToken" type="hidden" value="token123" /></html>',
+              {
+                status: 200,
+                headers: {
+                  "Set-Cookie": "__RequestVerificationToken=token123; Path=/;",
+                },
+              }
+            );
+          }),
+          http.post("https://www.topcashback.co.uk/logon/", () => {
+            return new HttpResponse("OK", {
+              status: 302,
+              headers: { "Set-Cookie": "SessionId=abc123; Path=/;" },
+            });
+          })
+        );
+        server.listen();
+
+        const tool = TopCashbackConnectorConfig.tools
+          .LOGIN as MCPToolDefinition;
+        const mockContext = createMockConnectorContext();
+        (
+          mockContext.getCredentials as ReturnType<typeof vi.fn>
+        ).mockResolvedValue({
+          email: "user@example.com",
+          password: "pass",
+        });
+
+        const actual = await tool.handler({}, mockContext);
+        server.close();
+
+        expect(actual).toContain("Login successful");
+        expect(mockContext.writeCache).toHaveBeenCalled();
+      });
+    });
+
+    describe("when credentials are invalid", () => {
+      it("returns failure message", async () => {
+        const server = setupServer(
+          http.get("https://www.topcashback.co.uk/logon/", () => {
+            return new HttpResponse("<html></html>", { status: 200 });
+          }),
+          http.post("https://www.topcashback.co.uk/logon/", () => {
+            return new HttpResponse("Unauthorized", { status: 401 });
+          })
+        );
+        server.listen();
+
+        const tool = TopCashbackConnectorConfig.tools
+          .LOGIN as MCPToolDefinition;
+        const mockContext = createMockConnectorContext();
+        (
+          mockContext.getCredentials as ReturnType<typeof vi.fn>
+        ).mockResolvedValue({
+          email: "bad@example.com",
+          password: "wrong",
+        });
+
+        const actual = await tool.handler({}, mockContext);
+        server.close();
+
+        expect(actual).toContain("Login failed");
+        expect(actual).toContain("Invalid credentials");
+      });
+    });
+  });
+
+  describe(".SEARCH_MERCHANTS", () => {
+    describe("when session is valid", () => {
+      it("returns merchants list", async () => {
+        const xml =
+          "<?xml version=\"1.0\" encoding=\"utf-8\"?><ArrayOfString><string>&lt;div&gt;SUGGESTED SEARCHES&lt;/div&gt;</string><string>&lt;span class='ac_name'&gt;eBay&lt;/span&gt;</string><string>&lt;span class='ac_name'&gt;Ebuyer&lt;/span&gt;</string></ArrayOfString>";
+        const server = setupServer(
+          http.post(
+            "https://www.topcashback.co.uk/Ajax.asmx/GetAutocompleteMerchants",
+            () => {
+              return new HttpResponse(xml, { status: 200 });
+            }
+          )
+        );
+        server.listen();
+
+        const tool = TopCashbackConnectorConfig.tools
+          .SEARCH_MERCHANTS as MCPToolDefinition;
+        const mockContext = createMockConnectorContext();
+        (mockContext.readCache as ReturnType<typeof vi.fn>).mockImplementation(
+          async (key) =>
+            key === "topcashback:session" ? "SessionId=abc123" : null
+        );
+
+        const actual = await tool.handler(
+          { query: "ebay", limit: 5 },
+          mockContext
+        );
+        server.close();
+
+        expect(actual).toContain("eBay");
+        expect(actual).toContain("Ebuyer");
+      });
+    });
+
+    describe("when no session is present", () => {
+      it("returns instruction to login", async () => {
+        const tool = TopCashbackConnectorConfig.tools
+          .SEARCH_MERCHANTS as MCPToolDefinition;
+        const mockContext = createMockConnectorContext();
+        (mockContext.readCache as ReturnType<typeof vi.fn>).mockResolvedValue(
+          null
+        );
+
+        const actual = await tool.handler({ query: "ebay" }, mockContext);
+
+        expect(actual).toContain("Please run the login tool first");
+      });
+    });
+
+    describe("when API returns an error status", () => {
+      it("returns error message", async () => {
+        const server = setupServer(
+          http.post(
+            "https://www.topcashback.co.uk/Ajax.asmx/GetAutocompleteMerchants",
+            () => new HttpResponse("Server error", { status: 500 })
+          )
+        );
+        server.listen();
+
+        const tool = TopCashbackConnectorConfig.tools
+          .SEARCH_MERCHANTS as MCPToolDefinition;
+        const mockContext = createMockConnectorContext();
+        (mockContext.readCache as ReturnType<typeof vi.fn>).mockResolvedValue({
+          value: { cookies: "SessionId=abc123" },
+        });
+
+        const actual = await tool.handler({ query: "ebay" }, mockContext);
+        server.close();
+
+        expect(actual).toContain("Merchant search failed");
+        expect(actual).toContain("500");
+      });
+    });
+  });
+
+  describe(".GET_CASHBACK_RATE", () => {
+    describe("when rate element exists", () => {
+      it("returns formatted rate", async () => {
+        const server = setupServer(
+          http.get("https://www.topcashback.co.uk/ebay/", () => {
+            return HttpResponse.text(
+              '<html><span class="merch-cat__rate">Up to 5% cashback</span></html>'
+            );
+          })
+        );
+        server.listen();
+
+        const tool = TopCashbackConnectorConfig.tools
+          .GET_CASHBACK_RATE as MCPToolDefinition;
+        const mockContext = createMockConnectorContext();
+        (mockContext.readCache as ReturnType<typeof vi.fn>).mockResolvedValue({
+          value: { cookies: "SessionId=abc123" },
+        });
+
+        const actual = await tool.handler(
+          { merchantSlug: "ebay" },
+          mockContext
+        );
+        server.close();
+
+        expect(actual).toContain("Cashback Rate: Up to 5% cashback");
+        expect(actual).toContain("Normalized");
+      });
+    });
+
+    describe("when rate element is missing", () => {
+      it("returns not found message", async () => {
+        const server = setupServer(
+          http.get("https://www.topcashback.co.uk/unknown/", () => {
+            return HttpResponse.text("<html><body>No rate here</body></html>");
+          })
+        );
+        server.listen();
+
+        const tool = TopCashbackConnectorConfig.tools
+          .GET_CASHBACK_RATE as MCPToolDefinition;
+        const mockContext = createMockConnectorContext();
+        (mockContext.readCache as ReturnType<typeof vi.fn>).mockImplementation(
+          async (key) =>
+            key === "topcashback:session" ? "SessionId=abc123" : null
+        );
+
+        const actual = await tool.handler(
+          { merchantSlug: "unknown" },
+          mockContext
+        );
+        server.close();
+
+        expect(actual).toContain("Cashback rate element not found");
+      });
+    });
+
+    describe("when page fetch fails", () => {
+      it("returns error message with status", async () => {
+        const server = setupServer(
+          http.get("https://www.topcashback.co.uk/failing/", () => {
+            return new HttpResponse("Not Found", { status: 404 });
+          })
+        );
+        server.listen();
+
+        const tool = TopCashbackConnectorConfig.tools
+          .GET_CASHBACK_RATE as MCPToolDefinition;
+        const mockContext = createMockConnectorContext();
+        (mockContext.readCache as ReturnType<typeof vi.fn>).mockImplementation(
+          async (key) =>
+            key === "topcashback:session" ? "SessionId=abc123" : null
+        );
+
+        const actual = await tool.handler(
+          { merchantSlug: "failing" },
+          mockContext
+        );
+        server.close();
+
+        expect(actual).toContain("Failed to get cashback rate");
+        expect(actual).toContain("404");
+      });
+    });
+  });
+
+  describe(".GET_CASHBACK_RATE_BEST_MATCH", () => {
+    describe("when merchants and rate exist", () => {
+      it("returns best match with normalized data", async () => {
+        const xml =
+          "<?xml version=\"1.0\"?><ArrayOfString><string>&lt;div&gt;SUGGESTED SEARCHES&lt;/div&gt;</string><string>&lt;span class='ac_name'&gt;eBay&lt;/span&gt;</string><string>&lt;span class='ac_name'&gt;Ebuyer&lt;/span&gt;</string></ArrayOfString>";
+        const server = setupServer(
+          http.post(
+            "https://www.topcashback.co.uk/Ajax.asmx/GetAutocompleteMerchants",
+            () => {
+              return new HttpResponse(xml, { status: 200 });
+            }
+          ),
+          http.get("https://www.topcashback.co.uk/ebay/", () => {
+            return HttpResponse.text(
+              '<html><span class="merch-cat__rate">Up to 5% cashback</span></html>'
+            );
+          })
+        );
+        server.listen();
+        const tool = TopCashbackConnectorConfig.tools
+          .GET_CASHBACK_RATE_BEST_MATCH as MCPToolDefinition;
+        const mockContext = createMockConnectorContext();
+        (mockContext.readCache as ReturnType<typeof vi.fn>).mockResolvedValue({
+          value: { cookies: "SessionId=abc123" },
+        });
+        // adapt to new cache key usage
+        (mockContext.readCache as ReturnType<typeof vi.fn>).mockImplementation(
+          async (key) =>
+            key === "topcashback:session" ? "SessionId=abc123" : null
+        );
+        const actual = await tool.handler({ query: "ebay" }, mockContext);
+        server.close();
+        expect(actual).toContain("Best Match: eBay");
+        expect(actual).toContain("Normalized");
+        expect(actual).toContain("5");
+      });
+    });
+
+    describe("when no session", () => {
+      it("instructs login first", async () => {
+        const tool = TopCashbackConnectorConfig.tools
+          .GET_CASHBACK_RATE_BEST_MATCH as MCPToolDefinition;
+        const mockContext = createMockConnectorContext();
+        (mockContext.readCache as ReturnType<typeof vi.fn>).mockImplementation(
+          async () => null
+        );
+        const actual = await tool.handler({ query: "ebay" }, mockContext);
+        expect(actual).toContain("login tool first");
+      });
+    });
+
+    describe("when no merchants found", () => {
+      it("returns no merchants message", async () => {
+        const server = setupServer(
+          http.post(
+            "https://www.topcashback.co.uk/Ajax.asmx/GetAutocompleteMerchants",
+            () => {
+              return new HttpResponse(
+                '<?xml version="1.0"?><ArrayOfString><string>&lt;div&gt;SUGGESTED SEARCHES&lt;/div&gt;</string></ArrayOfString>',
+                { status: 200 }
+              );
+            }
+          )
+        );
+        server.listen();
+        const tool = TopCashbackConnectorConfig.tools
+          .GET_CASHBACK_RATE_BEST_MATCH as MCPToolDefinition;
+        const mockContext = createMockConnectorContext();
+        (mockContext.readCache as ReturnType<typeof vi.fn>).mockImplementation(
+          async (key) =>
+            key === "topcashback:session" ? "SessionId=abc123" : null
+        );
+        const actual = await tool.handler({ query: "unknown" }, mockContext);
+        server.close();
+        expect(actual).toContain("No merchants found");
+      });
+    });
+  });
+});

--- a/packages/mcp-connectors/src/connectors/topcashback.ts
+++ b/packages/mcp-connectors/src/connectors/topcashback.ts
@@ -1,0 +1,378 @@
+import { mcpConnectorConfig } from "@stackone/mcp-config-types";
+import { parse as parseHTML } from "node-html-parser";
+import { z } from "zod";
+
+/**
+ * Minimal cookie jar helper – stores simple name=value pairs (ignores path, expiry, etc.)
+ */
+function extractCookies(setCookieHeaders: string[]): string {
+  const pairs: string[] = [];
+  for (const header of setCookieHeaders) {
+    const firstPart = header.split(";")[0]?.trim();
+    if (firstPart && !/^\s*$/.test(firstPart)) {
+      pairs.push(firstPart);
+    }
+  }
+  // Deduplicate by cookie name (last one wins)
+  const map = new Map<string, string>();
+  for (const p of pairs) {
+    const [name, ...rest] = p.split("=");
+    map.set(name, `${name}=${rest.join("=")}`);
+  }
+  return Array.from(map.values()).join("; ");
+}
+
+async function performLogin(
+  email: string,
+  password: string
+): Promise<{ cookies: string }> {
+  const LOGIN_URL =
+    "https://www.topcashback.co.uk/logon/?PageRequested=%2Fhome%2F";
+
+  // 1. Get login page to retrieve anti-forgery token + initial cookies
+  const loginPageResp = await fetch(LOGIN_URL, { method: "GET" });
+  if (!loginPageResp.ok) {
+    throw new Error(`Failed to load login page: ${loginPageResp.status}`);
+  }
+  const initialCookies = extractCookies(
+    loginPageResp.headers.getSetCookie
+      ? loginPageResp.headers.getSetCookie()
+      : []
+  );
+  const loginHtml = await loginPageResp.text();
+  const tokenMatch = loginHtml.match(
+    /name="__RequestVerificationToken"\s+type="hidden"\s+value="([^"]+)"/i
+  );
+  const antiForgery = tokenMatch ? tokenMatch[1] : "";
+  if (!antiForgery) {
+    // Tolerate missing token (site may change); continue with blank
+    console.warn(
+      "TopCashback login: anti-forgery token not found – proceeding without"
+    );
+  }
+
+  // 2. Submit credentials
+  const form = new URLSearchParams();
+  form.append("email", email);
+  form.append("password", password);
+  if (antiForgery) form.append("__RequestVerificationToken", antiForgery);
+
+  const loginResp = await fetch(LOGIN_URL, {
+    method: "POST",
+    headers: {
+      "Content-Type": "application/x-www-form-urlencoded",
+      "User-Agent": "Mozilla/5.0 MCP TopCashback Connector",
+      Cookie: initialCookies,
+      Accept: "text/html,application/xhtml+xml,application/xml;q=0.9,*/*;q=0.8",
+      "X-Requested-With": "XMLHttpRequest",
+    },
+    body: form.toString(),
+    redirect: "manual",
+  });
+
+  if (
+    loginResp.status === 302 ||
+    loginResp.status === 301 ||
+    loginResp.status === 200
+  ) {
+    const newCookies = extractCookies(
+      loginResp.headers.getSetCookie ? loginResp.headers.getSetCookie() : []
+    );
+    const allCookies = [initialCookies, newCookies].filter(Boolean).join("; ");
+    if (!allCookies) {
+      throw new Error("Login did not return any session cookies");
+    }
+    return { cookies: allCookies };
+  }
+  if (loginResp.status === 401) {
+    throw new Error("Invalid credentials (401)");
+  }
+  throw new Error(`Login failed: ${loginResp.status}`);
+}
+
+async function searchMerchants(
+  query: string,
+  limit: number,
+  cookies: string
+): Promise<string[]> {
+  const url =
+    "https://www.topcashback.co.uk/Ajax.asmx/GetAutocompleteMerchants";
+  const timestamp = Date.now().toString();
+  const body = new URLSearchParams({
+    q: query,
+    limit: String(limit),
+    timestamp,
+  }).toString();
+  const resp = await fetch(url, {
+    method: "POST",
+    headers: {
+      "Content-Type": "application/x-www-form-urlencoded; charset=UTF-8",
+      Accept: "application/xml, text/xml, */*; q=0.01",
+      "X-Requested-With": "XMLHttpRequest",
+      Cookie: cookies,
+      Referer: "https://www.topcashback.co.uk/home/",
+    },
+    body,
+  });
+  if (!resp.ok) {
+    if (resp.status === 401 || resp.status === 403) {
+      throw new Error("Unauthorized – session expired, please login again");
+    }
+    throw new Error(`Search failed: ${resp.status}`);
+  }
+  const xml = await resp.text();
+  const matches = Array.from(xml.matchAll(/<string>([\s\S]*?)<\/string>/g)).map(
+    (m) => m[1]
+  );
+  const merchants: string[] = [];
+  for (const fragment of matches) {
+    if (fragment.includes("SUGGESTED SEARCHES")) continue; // skip header block
+    // Decode minimal HTML entities and parse
+    const decoded = fragment
+      .replace(/&lt;/g, "<")
+      .replace(/&gt;/g, ">")
+      .replace(/&amp;/g, "&");
+    const root = parseHTML(decoded);
+    const name = root.querySelector(".ac_name")?.text?.trim();
+    if (name) merchants.push(name);
+  }
+  return merchants;
+}
+
+async function fetchCashbackRate(
+  slug: string,
+  cookies?: string
+): Promise<{ rate: string | null; rawText: string | null }> {
+  const url = `https://www.topcashback.co.uk/${slug.replace(
+    /[^a-z0-9-]/gi,
+    ""
+  )}/`;
+  const resp = await fetch(url, {
+    headers: {
+      "User-Agent": "Mozilla/5.0 MCP TopCashback Connector",
+      Accept: "text/html,application/xhtml+xml,application/xml;q=0.9,*/*;q=0.8",
+      ...(cookies ? { Cookie: cookies } : {}),
+    },
+  });
+  if (!resp.ok) {
+    throw new Error(`Failed to fetch merchant page (${resp.status})`);
+  }
+  const html = await resp.text();
+  const root = parseHTML(html);
+  const span = root.querySelector(".merch-cat__rate");
+  const raw = span ? span.text.trim().replace(/\s+/g, " ") : null;
+  return { rate: raw, rawText: raw };
+}
+
+export const TopCashbackConnectorConfig = mcpConnectorConfig({
+  name: "TopCashback",
+  key: "topcashback",
+  version: "1.0.0",
+  logo: "https://stackone-logos.com/api/topcashback/filled/svg",
+  credentials: z.object({
+    email: z.string().describe("Your TopCashback account email"),
+    password: z.string().describe("Your TopCashback account password"),
+  }),
+  setup: z.object({}),
+  examplePrompt:
+    'Login to TopCashback, search for the merchant "eBay" and return the current publicly shown cashback rate.',
+  tools: (tool) => ({
+    LOGIN: tool({
+      name: "topcashback_login",
+      description:
+        "Authenticate with TopCashback and cache a session. Provide email/password args or have stored credentials.",
+      schema: z.object({
+        email: z
+          .string()
+          .optional()
+          .describe("TopCashback account email (optional if stored credentials configured)"),
+        password: z
+          .string()
+          .optional()
+          .describe("TopCashback account password (optional if stored credentials configured)"),
+      }),
+      handler: async (args, context) => {
+        try {
+          let stored: any = {};
+          try {
+            stored = (await context.getCredentials()) || {};
+          } catch {
+            // ignore if credentials store not available
+          }
+          const email = (args.email || stored.email) as string | undefined;
+            const password = (args.password || stored.password) as
+            | string
+            | undefined;
+          if (!email || !password) {
+            return "Missing credentials: supply email/password arguments or configure stored credentials.";
+          }
+          const session = await performLogin(email, password);
+          await context.writeCache("topcashback:session", session.cookies);
+          return "Login successful";
+        } catch (e) {
+          return `Login failed: ${e instanceof Error ? e.message : String(e)}`;
+        }
+      },
+    }),
+    SEARCH_MERCHANTS: tool({
+      name: "topcashback_search_merchants",
+      description:
+        "Search for merchants by name using TopCashback autocomplete (requires prior login)",
+      schema: z.object({
+        query: z.string().describe("Merchant search query fragment"),
+        limit: z.number().default(10).describe("Maximum merchants to return"),
+      }),
+      handler: async (args, context) => {
+        try {
+          const cookies = (await context.readCache("topcashback:session")) as
+            | string
+            | null;
+          if (!cookies) {
+            return "No active session found. Please run the login tool first.";
+          }
+          const merchants = await searchMerchants(
+            args.query,
+            args.limit,
+            cookies
+          );
+          if (merchants.length === 0) return "No merchants found for query";
+          return merchants.join("\n");
+        } catch (e) {
+          return `Merchant search failed: ${
+            e instanceof Error ? e.message : String(e)
+          }`;
+        }
+      },
+    }),
+    GET_CASHBACK_RATE: tool({
+      name: "topcashback_get_cashback_rate",
+      description:
+        "Fetch and return the displayed cashback rate for a merchant slug (requires login for member-only rates)",
+      schema: z.object({
+        merchantSlug: z
+          .string()
+          .describe(
+            'Merchant slug as in URL, e.g. "ebay" for https://www.topcashback.co.uk/ebay/'
+          ),
+      }),
+      handler: async (args, context) => {
+        try {
+          const cookies = (await context.readCache("topcashback:session")) as
+            | string
+            | null;
+          const { rate } = await fetchCashbackRate(
+            args.merchantSlug,
+            cookies === null ? undefined : cookies
+          );
+          if (!rate) return "Cashback rate element not found";
+          const normalized = normalizePercentage(rate);
+          return `Merchant: ${
+            args.merchantSlug
+          }\nCashback Rate: ${rate}\nNormalized: ${JSON.stringify(normalized)}`;
+        } catch (e) {
+          return `Failed to get cashback rate: ${
+            e instanceof Error ? e.message : String(e)
+          }`;
+        }
+      },
+    }),
+    GET_CASHBACK_RATE_BEST_MATCH: tool({
+      name: "topcashback_get_cashback_rate_best_match",
+      description:
+        "Search merchants, pick the best matching merchant for the given query, then fetch and normalize its cashback rate",
+      schema: z.object({
+        query: z.string().describe("Merchant name query"),
+        limit: z
+          .number()
+          .default(10)
+          .describe("How many autocomplete results to consider"),
+      }),
+      handler: async (args, context) => {
+        try {
+          const cookies = (await context.readCache("topcashback:session")) as
+            | string
+            | null;
+          if (!cookies)
+            return "No active session found. Please run the login tool first.";
+          const merchants = await searchMerchants(
+            args.query,
+            args.limit,
+            cookies
+          );
+          if (merchants.length === 0) return "No merchants found for query";
+          const best = pickBestMatch(args.query, merchants);
+          if (!best) return "Unable to determine best match";
+          const slug = nameToSlug(best);
+          const { rate } = await fetchCashbackRate(slug, cookies);
+          if (!rate)
+            return `Best match '${best}' found but cashback rate element not present`;
+          const normalized = normalizePercentage(rate);
+          return `Best Match: ${best}\nSlug: ${slug}\nCashback Rate: ${rate}\nNormalized: ${JSON.stringify(
+            normalized
+          )}`;
+        } catch (e) {
+          return `Failed to get best match cashback rate: ${
+            e instanceof Error ? e.message : String(e)
+          }`;
+        }
+      },
+    }),
+  }),
+});
+
+// --- Helpers for best-match and normalization ---
+function scoreCandidate(query: string, candidate: string): number {
+  const q = query.toLowerCase();
+  const c = candidate.toLowerCase();
+  if (q === c) return 100;
+  if (c.startsWith(q)) return 80;
+  if (c.includes(q)) return 60;
+  // simple overlap score
+  let overlap = 0;
+  for (const ch of new Set(q.split(""))) if (c.includes(ch)) overlap++;
+  return overlap;
+}
+
+function pickBestMatch(query: string, candidates: string[]): string | null {
+  let best: string | null = null;
+  let bestScore = -1;
+  for (const c of candidates) {
+    const s = scoreCandidate(query, c);
+    if (s > bestScore) {
+      bestScore = s;
+      best = c;
+    }
+  }
+  return best;
+}
+
+function nameToSlug(name: string): string {
+  return name.toLowerCase().replace(/[^a-z0-9]+/g, "");
+}
+
+interface NormalizedPercentageInfo {
+  raw: string;
+  percentages: number[];
+  minPercentage: number | null;
+  maxPercentage: number | null;
+  range: boolean;
+}
+
+function normalizePercentage(rawInput: string): NormalizedPercentageInfo {
+  const raw = String(rawInput);
+  const percentMatches = Array.from(raw.matchAll(/(\d+(?:\.\d+)?)\s*%/g)).map(
+    (m) => parseFloat(m[1] as string)
+  );
+  const percentages = percentMatches.sort((a, b) => a - b);
+  const min: number | null = percentages.length ? percentages[0]! : null;
+  const max: number | null = percentages.length
+    ? percentages[percentages.length - 1]!
+    : null;
+  return {
+    raw: raw,
+    percentages,
+    minPercentage: min,
+    maxPercentage: max,
+    range: !!(min !== null && max !== null && min !== max),
+  };
+}

--- a/packages/mcp-connectors/src/index.ts
+++ b/packages/mcp-connectors/src/index.ts
@@ -1,46 +1,48 @@
-import type { MCPConnectorConfig } from '@stackone/mcp-config-types';
+import type { MCPConnectorConfig } from "@stackone/mcp-config-types";
 
 // Import all connectors for the array
-import { AsanaConnectorConfig } from './connectors/asana';
-import { AttioConnectorConfig } from './connectors/attio';
-import { AwsConnectorConfig } from './connectors/aws';
-import { DatadogConnectorConfig } from './connectors/datadog';
-import { DeelConnectorConfig } from './connectors/deel';
-import { DeepseekConnectorConfig } from './connectors/deepseek';
-import { DocumentationConnectorConfig } from './connectors/documentation';
-import { DuckDuckGoConnectorConfig } from './connectors/duckduckgo';
-import { ElevenLabsConnectorConfig } from './connectors/elevenlabs';
-import { ExaConnectorConfig } from './connectors/exa';
-import { FalConnectorConfig } from './connectors/fal';
-import { FirefliesConnectorConfig } from './connectors/fireflies';
-import { GitHubConnectorConfig } from './connectors/github';
-import { GoogleDriveConnectorConfig } from './connectors/google-drive';
-import { HiBobConnectorConfig } from './connectors/hibob';
-import { HubSpotConnectorConfig } from './connectors/hubspot';
-import { IncidentConnectorConfig } from './connectors/incident';
-import { JiraConnectorConfig } from './connectors/jira';
-import { LangsmithConnectorConfig } from './connectors/langsmith';
-import { LinearConnectorConfig } from './connectors/linear';
-import { LinkedInConnectorConfig } from './connectors/linkedin';
-import { NotionConnectorConfig } from './connectors/notion';
-import { OnePasswordConnectorConfig } from './connectors/onepassword';
-import { ParallelConnectorConfig } from './connectors/parallel';
-import { PerplexityConnectorConfig } from './connectors/perplexity';
-import { ProducthuntConnectorConfig } from './connectors/producthunt';
-import { LogfireConnectorConfig } from './connectors/pydantic-logfire';
-import { PylonConnectorConfig } from './connectors/pylon';
-import { ReplicateConnectorConfig } from './connectors/replicate';
-import { SequentialThinkingConnectorConfig } from './connectors/sequential-thinking';
-import { SlackConnectorConfig } from './connectors/slack';
-import { StackOneConnectorConfig } from './connectors/stackone';
-import { StravaConnectorConfig } from './connectors/strava';
-import { SupabaseConnectorConfig } from './connectors/supabase';
-import { TestConnectorConfig } from './connectors/test';
-import { TinybirdConnectorConfig } from './connectors/tinybird';
-import { TodoistConnectorConfig } from './connectors/todoist';
-import { TurbopufferConnectorConfig } from './connectors/turbopuffer';
-import { WandbConnectorConfig } from './connectors/wandb';
-import { XeroConnectorConfig } from './connectors/xero';
+import { AsanaConnectorConfig } from "./connectors/asana";
+import { AttioConnectorConfig } from "./connectors/attio";
+import { AwsConnectorConfig } from "./connectors/aws";
+import { DatadogConnectorConfig } from "./connectors/datadog";
+import { DeelConnectorConfig } from "./connectors/deel";
+import { DeepseekConnectorConfig } from "./connectors/deepseek";
+import { DocumentationConnectorConfig } from "./connectors/documentation";
+import { DuckDuckGoConnectorConfig } from "./connectors/duckduckgo";
+import { ElevenLabsConnectorConfig } from "./connectors/elevenlabs";
+import { ExaConnectorConfig } from "./connectors/exa";
+import { FalConnectorConfig } from "./connectors/fal";
+import { FirefliesConnectorConfig } from "./connectors/fireflies";
+import { GitHubConnectorConfig } from "./connectors/github";
+import { GoogleDriveConnectorConfig } from "./connectors/google-drive";
+import { HiBobConnectorConfig } from "./connectors/hibob";
+import { HubSpotConnectorConfig } from "./connectors/hubspot";
+import { IncidentConnectorConfig } from "./connectors/incident";
+import { JiraConnectorConfig } from "./connectors/jira";
+import { LangsmithConnectorConfig } from "./connectors/langsmith";
+import { LinearConnectorConfig } from "./connectors/linear";
+import { LinkedInConnectorConfig } from "./connectors/linkedin";
+import { NotionConnectorConfig } from "./connectors/notion";
+import { OnePasswordConnectorConfig } from "./connectors/onepassword";
+import { ParallelConnectorConfig } from "./connectors/parallel";
+import { PerplexityConnectorConfig } from "./connectors/perplexity";
+import { ProducthuntConnectorConfig } from "./connectors/producthunt";
+import { LogfireConnectorConfig } from "./connectors/pydantic-logfire";
+import { PylonConnectorConfig } from "./connectors/pylon";
+import { QuidcoConnectorConfig } from "./connectors/quidco";
+import { ReplicateConnectorConfig } from "./connectors/replicate";
+import { SequentialThinkingConnectorConfig } from "./connectors/sequential-thinking";
+import { SlackConnectorConfig } from "./connectors/slack";
+import { StackOneConnectorConfig } from "./connectors/stackone";
+import { StravaConnectorConfig } from "./connectors/strava";
+import { SupabaseConnectorConfig } from "./connectors/supabase";
+import { TestConnectorConfig } from "./connectors/test";
+import { TinybirdConnectorConfig } from "./connectors/tinybird";
+import { TodoistConnectorConfig } from "./connectors/todoist";
+import { TopCashbackConnectorConfig } from "./connectors/topcashback";
+import { TurbopufferConnectorConfig } from "./connectors/turbopuffer";
+import { WandbConnectorConfig } from "./connectors/wandb";
+import { XeroConnectorConfig } from "./connectors/xero";
 
 export const Connectors: readonly MCPConnectorConfig[] = [
   TestConnectorConfig,
@@ -83,11 +85,11 @@ export const Connectors: readonly MCPConnectorConfig[] = [
   TurbopufferConnectorConfig,
   WandbConnectorConfig,
   XeroConnectorConfig,
+  TopCashbackConnectorConfig,
+  QuidcoConnectorConfig,
 ] as const;
 
 export {
-  TestConnectorConfig,
-  StackOneConnectorConfig,
   AsanaConnectorConfig,
   AttioConnectorConfig,
   AwsConnectorConfig,
@@ -99,12 +101,12 @@ export {
   ElevenLabsConnectorConfig,
   ExaConnectorConfig,
   FalConnectorConfig,
+  FirefliesConnectorConfig,
   GitHubConnectorConfig,
   GoogleDriveConnectorConfig,
   HiBobConnectorConfig,
   HubSpotConnectorConfig,
   IncidentConnectorConfig,
-  FirefliesConnectorConfig,
   JiraConnectorConfig,
   LangsmithConnectorConfig,
   LinearConnectorConfig,
@@ -116,13 +118,17 @@ export {
   PerplexityConnectorConfig,
   ProducthuntConnectorConfig,
   PylonConnectorConfig,
+  QuidcoConnectorConfig,
   ReplicateConnectorConfig,
   SequentialThinkingConnectorConfig,
   SlackConnectorConfig,
+  StackOneConnectorConfig,
   StravaConnectorConfig,
   SupabaseConnectorConfig,
+  TestConnectorConfig,
   TinybirdConnectorConfig,
   TodoistConnectorConfig,
+  TopCashbackConnectorConfig,
   TurbopufferConnectorConfig,
   WandbConnectorConfig,
   XeroConnectorConfig,


### PR DESCRIPTION
# Quidco & TopCashback MCP Connectors  

## What’s This About?  

When I shop online at places like **eBay, AliExpress, or Adidas**, I always want the **best cashback rate**. The problem is, today I need to:  

1. Log into Quidco.  
2. Search for the retailer.  
3. Log into TopCashback.  
4. Search again.  
5. Maybe even check Rakuten.  
6. Manually compare offers.  
7. Click the winning affiliate link.  

It’s repetitive, slow, and easy to miss a better promo. Cashback rates change often, and unless you check every site manually, you risk leaving free money on the table.  

With these **MCP connectors**, any agent, copilot, or automation can **query cashback rates from multiple sites at once**, compare them, and open the best link—saving time and maximizing rewards.  

---

## What It Actually Does  

Right now I’ve implemented **two connectors**—one for **TopCashback**, one for **Quidco**. Each exposes structured tools:  

| Connector   | Tools                                                                                                                             | Purpose                                                                                     |
| ----------- | --------------------------------------------------------------------------------------------------------------------------------- | ------------------------------------------------------------------------------------------- |
| TopCashback | `topcashback_login`, `topcashback_search_merchants`, `topcashback_get_cashback_rate`, `topcashback_get_cashback_rate_best_match`  | Auth, merchant autocomplete, cashback rate lookup, normalized best-match results.           |
| Quidco      | `quidco_login`, `quidco_get_user`, `quidco_search_merchants`, `quidco_get_cashback_offer`, `quidco_get_cashback_offer_best_match` | Auth, profile fetch, merchant search, cashback offer extraction, normalized best-match API. |

Both connectors parse cashback offers into **structured JSON**:  
- `"Up to 5%"` → `{min=5, max=5}`  
- `"2% – 8%"` → `{min=2, max=8, range=true}`  

Matching is done via a lightweight heuristic:  
**exact > prefix > substring > overlap**.  
It’s deterministic and fast, but can evolve later into fuzzy/token matching.  

---

## Developer Experience  

**Architecture:**  

```
apps/server (generic MCP host)
packages/mcp-connectors
  └─ src/connectors/
       topcashback.ts
       quidco.ts
       ...
```

**Testing Locally:**  

```bash
bun run build

# Run connectors
bun run apps/server/src/index.ts --port 3001 --connector topcashback
bun run apps/server/src/index.ts --port 3002 --connector quidco

# Fetch tools
curl -X POST http://localhost:3001/mcp -d '{"method":"tools/list"}'

# Example usage
curl -X POST http://localhost:3001/mcp \
  -d '{"method":"tools/call","params":{"name":"topcashback_get_cashback_rate_best_match","arguments":{"query":"ebay"}}}'
```

---

## Why This Matters  

This is the foundation of a **multi-site cashback comparison agent**.  

Imagine telling Disco.dev (or Claude/Gemini/other MCP clients):  

> “Check Adidas on Quidco and TopCashback, and tell me which has the highest rate.”  

The agent logs in, queries both, normalizes the percentages, and instantly replies with the best option.  

No more tab-hopping, no more guessing. Just **automated money-saving**.  

---

## Roadmap  

**Near-term:**  
- Add Rakuten connector.  
- Build `cashback_compare_best` meta-tool (query all at once, return champion + deltas).  
- Extract reusable `cashback-utils.ts`.  

**Mid-term:**  
- Fuzzy string matching.  
- Session persistence + auto-relogin.  
- Rate change alerts.  

**Long-term:**  
- Affiliate deep link capture (one-click redirection).  
- Historical cashback database for trend analysis.  
- Reliability scoring per connector.  

---

## Limitations (for now)  

- No Rakuten yet.  
- Simple string matching (no fuzzy search).  
- Sessions stored in memory only.  
- Doesn’t yet open affiliate links directly.  

---

## Hackathon Contribution Ideas  

- Add more cashback providers (Rakuten, Honey Gold, Capital One Shopping).  
- Build comparison meta-tool with ranking.  
- Add rate history + alerts.  
- Improve fuzzy merchant matching.  

---

## PR Summary  

> **Adds Quidco & TopCashback MCP connectors.**  
> Enables authenticated merchant search, cashback rate extraction, best-match resolution, and normalized percentage outputs. Lays groundwork for a meta-tool that can instantly compare rates across sites.  

**Benefits:** Automatable multi-site cashback comparison, faster decisions, money saved, and an extensible framework for affiliate automation.  