### PR TITLE
feat: add Graphy connector with board and dataset management

### DIFF
--- a/packages/mcp-connectors/src/connectors/graphy.spec.ts
+++ b/packages/mcp-connectors/src/connectors/graphy.spec.ts
@@ -1,0 +1,428 @@
+import type { MCPToolDefinition } from '@stackone/mcp-config-types';
+import { http, HttpResponse } from 'msw';
+import { setupServer } from 'msw/node';
+import { afterAll, afterEach, beforeAll, describe, expect, it } from 'vitest';
+import { createMockConnectorContext } from '../__mocks__/context';
+import { GraphyConnectorConfig } from './graphy';
+
+const server = setupServer();
+
+beforeAll(() => server.listen());
+afterEach(() => server.resetHandlers());
+afterAll(() => server.close());
+
+describe('#GraphyConnector', () => {
+  describe('.LIST_BOARDS', () => {
+    describe('when API returns boards successfully', () => {
+      describe('and no pagination parameters are provided', () => {
+        it('returns list of boards with default pagination', async () => {
+          const mockBoards = [
+            {
+              id: 'board-1',
+              title: 'Sales Dashboard',
+              type: 'bar',
+              description: 'Monthly sales data',
+              created_at: '2024-01-01T00:00:00Z',
+              updated_at: '2024-01-02T00:00:00Z',
+              is_public: false,
+            },
+            {
+              id: 'board-2',
+              title: 'User Growth',
+              type: 'line',
+              description: 'User growth over time',
+              created_at: '2024-01-01T00:00:00Z',
+              updated_at: '2024-01-02T00:00:00Z',
+              is_public: true,
+            },
+          ];
+
+          server.use(
+            http.get('https://api.graphy.app/rest/v1/boards', ({ request }) => {
+              const url = new URL(request.url);
+              expect(url.searchParams.get('limit')).toBe('50');
+              expect(url.searchParams.get('offset')).toBe('0');
+              return HttpResponse.json({ results: mockBoards });
+            })
+          );
+
+          const tool = GraphyConnectorConfig.tools.LIST_BOARDS as MCPToolDefinition;
+          const mockContext = createMockConnectorContext({
+            credentials: { apiToken: 'test-token' },
+          });
+
+          const actual = await tool.handler({}, mockContext);
+
+          expect(actual).toBe(JSON.stringify(mockBoards, null, 2));
+        });
+      });
+
+      describe('and custom pagination parameters are provided', () => {
+        it('returns list of boards with specified pagination', async () => {
+          const mockBoards = [
+            {
+              id: 'board-3',
+              title: 'Revenue Chart',
+              type: 'pie',
+              description: 'Revenue breakdown',
+              created_at: '2024-01-01T00:00:00Z',
+              updated_at: '2024-01-02T00:00:00Z',
+              is_public: false,
+            },
+          ];
+
+          server.use(
+            http.get('https://api.graphy.app/rest/v1/boards', ({ request }) => {
+              const url = new URL(request.url);
+              expect(url.searchParams.get('limit')).toBe('10');
+              expect(url.searchParams.get('offset')).toBe('5');
+              return HttpResponse.json({ results: mockBoards });
+            })
+          );
+
+          const tool = GraphyConnectorConfig.tools.LIST_BOARDS as MCPToolDefinition;
+          const mockContext = createMockConnectorContext({
+            credentials: { apiToken: 'test-token' },
+          });
+
+          const actual = await tool.handler({ limit: 10, offset: 5 }, mockContext);
+
+          expect(actual).toBe(JSON.stringify(mockBoards, null, 2));
+        });
+      });
+    });
+
+    describe('when API returns unauthorized error', () => {
+      it('returns authorization error message', async () => {
+        server.use(
+          http.get('https://api.graphy.app/rest/v1/boards', () => {
+            return HttpResponse.json({ message: 'Unauthorized access' }, { status: 401 });
+          })
+        );
+
+        const tool = GraphyConnectorConfig.tools.LIST_BOARDS as MCPToolDefinition;
+        const mockContext = createMockConnectorContext({
+          credentials: { apiToken: 'test-token' },
+        });
+
+        const actual = await tool.handler({}, mockContext);
+
+        expect(actual).toBe('Error: Unauthorized. Please check your Graphy API token and permissions.');
+      });
+    });
+
+    describe('when API returns not found error', () => {
+      it('returns not found error message with API guidance', async () => {
+        server.use(
+          http.get('https://api.graphy.app/rest/v1/boards', () => {
+            return HttpResponse.json({ message: 'Not found' }, { status: 404 });
+          })
+        );
+
+        const tool = GraphyConnectorConfig.tools.LIST_BOARDS as MCPToolDefinition;
+        const mockContext = createMockConnectorContext({
+          credentials: { apiToken: 'test-token' },
+        });
+
+        const actual = await tool.handler({}, mockContext);
+
+        expect(actual).toBe('Error: API endpoint not found. The Graphy REST API may not be available yet or the endpoint path may have changed. Please check the API documentation at https://visualize.graphy.app/rest-api for the correct endpoints.');
+      });
+    });
+  });
+
+  describe('.GET_BOARD', () => {
+    describe('when board exists', () => {
+      it('returns board details', async () => {
+        const mockBoard = {
+          id: 'board-1',
+          title: 'Sales Dashboard',
+          type: 'bar',
+          description: 'Monthly sales data',
+          created_at: '2024-01-01T00:00:00Z',
+          updated_at: '2024-01-02T00:00:00Z',
+          is_public: false,
+        };
+
+        server.use(
+          http.get('https://api.graphy.app/rest/v1/boards/board-1', () => {
+            return HttpResponse.json(mockBoard);
+          })
+        );
+
+        const tool = GraphyConnectorConfig.tools.GET_BOARD as MCPToolDefinition;
+        const mockContext = createMockConnectorContext({
+          credentials: { apiToken: 'test-token' },
+        });
+
+        const actual = await tool.handler({ boardId: 'board-1' }, mockContext);
+
+        expect(actual).toBe(JSON.stringify(mockBoard, null, 2));
+      });
+    });
+
+    describe('when board does not exist', () => {
+      it('returns not found error message', async () => {
+        server.use(
+          http.get('https://api.graphy.app/rest/v1/boards/nonexistent', () => {
+            return HttpResponse.json({ message: 'Board not found' }, { status: 404 });
+          })
+        );
+
+        const tool = GraphyConnectorConfig.tools.GET_BOARD as MCPToolDefinition;
+        const mockContext = createMockConnectorContext({
+          credentials: { apiToken: 'test-token' },
+        });
+
+        const actual = await tool.handler({ boardId: 'nonexistent' }, mockContext);
+
+        expect(actual).toBe('Error: API endpoint not found. The Graphy REST API may not be available yet or the endpoint path may have changed. Please check the API documentation at https://visualize.graphy.app/rest-api for the correct endpoints.');
+      });
+    });
+  });
+
+  describe('.CREATE_BOARD', () => {
+    describe('when board creation is successful', () => {
+      it('returns created board details', async () => {
+        const mockBoard = {
+          id: 'board-new',
+          title: 'New Board',
+          type: 'line',
+          description: 'A new board',
+          created_at: '2024-01-01T00:00:00Z',
+          updated_at: '2024-01-01T00:00:00Z',
+          is_public: false,
+        };
+
+        server.use(
+          http.post('https://api.graphy.app/rest/v1/boards', () => {
+            return HttpResponse.json(mockBoard);
+          })
+        );
+
+        const tool = GraphyConnectorConfig.tools.CREATE_BOARD as MCPToolDefinition;
+        const mockContext = createMockConnectorContext({
+          credentials: { apiToken: 'test-token' },
+        });
+
+        const actual = await tool.handler(
+          { title: 'New Board', type: 'line', description: 'A new board' },
+          mockContext
+        );
+
+        expect(actual).toBe(JSON.stringify(mockBoard, null, 2));
+      });
+    });
+
+    describe('when board creation fails due to validation', () => {
+      it('returns validation error message', async () => {
+        server.use(
+          http.post('https://api.graphy.app/rest/v1/boards', () => {
+            return HttpResponse.json({ message: 'Title is required' }, { status: 400 });
+          })
+        );
+
+        const tool = GraphyConnectorConfig.tools.CREATE_BOARD as MCPToolDefinition;
+        const mockContext = createMockConnectorContext({
+          credentials: { apiToken: 'test-token' },
+        });
+
+        const actual = await tool.handler({ title: '', type: 'line' }, mockContext);
+
+        expect(actual).toBe('Error: Title is required');
+      });
+    });
+  });
+
+  describe('.UPDATE_BOARD', () => {
+    describe('when board update is successful', () => {
+      it('returns updated board details', async () => {
+        const mockBoard = {
+          id: 'board-1',
+          title: 'Updated Board',
+          type: 'bar',
+          description: 'Updated description',
+          created_at: '2024-01-01T00:00:00Z',
+          updated_at: '2024-01-03T00:00:00Z',
+          is_public: true,
+        };
+
+        server.use(
+          http.put('https://api.graphy.app/rest/v1/boards/board-1', () => {
+            return HttpResponse.json(mockBoard);
+          })
+        );
+
+        const tool = GraphyConnectorConfig.tools.UPDATE_BOARD as MCPToolDefinition;
+        const mockContext = createMockConnectorContext({
+          credentials: { apiToken: 'test-token' },
+        });
+
+        const actual = await tool.handler(
+          { boardId: 'board-1', title: 'Updated Board', description: 'Updated description' },
+          mockContext
+        );
+
+        expect(actual).toBe(JSON.stringify(mockBoard, null, 2));
+      });
+    });
+  });
+
+  describe('.DELETE_BOARD', () => {
+    describe('when board deletion is successful', () => {
+      it('returns success message', async () => {
+        server.use(
+          http.delete('https://api.graphy.app/rest/v1/boards/board-1', () => {
+            return new HttpResponse(null, { status: 204 });
+          })
+        );
+
+        const tool = GraphyConnectorConfig.tools.DELETE_BOARD as MCPToolDefinition;
+        const mockContext = createMockConnectorContext({
+          credentials: { apiToken: 'test-token' },
+        });
+
+        const actual = await tool.handler({ boardId: 'board-1' }, mockContext);
+
+        expect(actual).toBe('Board board-1 deleted successfully');
+      });
+    });
+  });
+
+  describe('.LIST_DATASETS', () => {
+    describe('when API returns datasets successfully', () => {
+      it('returns list of datasets', async () => {
+        const mockDatasets = [
+          {
+            id: 'dataset-1',
+            name: 'Sales Data',
+            description: 'Monthly sales figures',
+            columns: [
+              { name: 'month', type: 'string', nullable: false },
+              { name: 'revenue', type: 'number', nullable: false },
+            ],
+            row_count: 12,
+            created_at: '2024-01-01T00:00:00Z',
+            updated_at: '2024-01-02T00:00:00Z',
+          },
+        ];
+
+        server.use(
+          http.get('https://api.graphy.app/rest/v1/datasets', () => {
+            return HttpResponse.json({ results: mockDatasets });
+          })
+        );
+
+        const tool = GraphyConnectorConfig.tools.LIST_DATASETS as MCPToolDefinition;
+        const mockContext = createMockConnectorContext({
+          credentials: { apiToken: 'test-token' },
+        });
+
+        const actual = await tool.handler({}, mockContext);
+
+        expect(actual).toBe(JSON.stringify(mockDatasets, null, 2));
+      });
+    });
+  });
+
+  describe('.CREATE_DATASET', () => {
+    describe('when dataset creation is successful', () => {
+      it('returns created dataset details', async () => {
+        const mockDataset = {
+          id: 'dataset-new',
+          name: 'Test Dataset',
+          description: 'A test dataset',
+          columns: [
+            { name: 'id', type: 'number', nullable: false },
+            { name: 'name', type: 'string', nullable: false },
+          ],
+          row_count: 2,
+          created_at: '2024-01-01T00:00:00Z',
+          updated_at: '2024-01-01T00:00:00Z',
+        };
+
+        server.use(
+          http.post('https://api.graphy.app/rest/v1/datasets', () => {
+            return HttpResponse.json(mockDataset);
+          })
+        );
+
+        const tool = GraphyConnectorConfig.tools.CREATE_DATASET as MCPToolDefinition;
+        const mockContext = createMockConnectorContext({
+          credentials: { apiToken: 'test-token' },
+        });
+
+        const actual = await tool.handler(
+          {
+            name: 'Test Dataset',
+            data: [
+              [1, 'John'],
+              [2, 'Jane'],
+            ],
+            columns: [
+              { name: 'id', type: 'number' },
+              { name: 'name', type: 'string' },
+            ],
+            description: 'A test dataset',
+          },
+          mockContext
+        );
+
+        expect(actual).toBe(JSON.stringify(mockDataset, null, 2));
+      });
+    });
+  });
+
+  describe('.GET_BOARD_DATA', () => {
+    describe('when board data is retrieved successfully', () => {
+      it('returns board data in JSON format', async () => {
+        const mockData = [
+          { month: 'January', revenue: 10000 },
+          { month: 'February', revenue: 12000 },
+        ];
+
+        server.use(
+          http.get('https://api.graphy.app/rest/v1/boards/board-1/data', ({ request }) => {
+            const url = new URL(request.url);
+            expect(url.searchParams.get('format')).toBe('json');
+            return HttpResponse.json(mockData);
+          })
+        );
+
+        const tool = GraphyConnectorConfig.tools.GET_BOARD_DATA as MCPToolDefinition;
+        const mockContext = createMockConnectorContext({
+          credentials: { apiToken: 'test-token' },
+        });
+
+        const actual = await tool.handler({ boardId: 'board-1', format: 'json' }, mockContext);
+
+        expect(actual).toBe(JSON.stringify(mockData, null, 2));
+      });
+    });
+  });
+
+  describe('.SHARE_BOARD', () => {
+    describe('when board sharing is successful', () => {
+      it('returns success message with embed URL', async () => {
+        const mockResponse = {
+          embed_url: 'https://visualize.graphy.app/embed/board-1',
+        };
+
+        server.use(
+          http.post('https://api.graphy.app/rest/v1/boards/board-1/share', () => {
+            return HttpResponse.json(mockResponse);
+          })
+        );
+
+        const tool = GraphyConnectorConfig.tools.SHARE_BOARD as MCPToolDefinition;
+        const mockContext = createMockConnectorContext({
+          credentials: { apiToken: 'test-token' },
+        });
+
+        const actual = await tool.handler({ boardId: 'board-1', isPublic: true }, mockContext);
+
+        expect(actual).toBe('Board shared successfully. Embed URL: https://visualize.graphy.app/embed/board-1');
+      });
+    });
+  });
+});

--- a/packages/mcp-connectors/src/connectors/graphy.ts
+++ b/packages/mcp-connectors/src/connectors/graphy.ts
@@ -1,0 +1,513 @@
+import { mcpConnectorConfig } from '@stackone/mcp-config-types';
+import { z } from 'zod';
+
+const GRAPHY_API_BASE = 'https://api.graphy.app/rest/v1';
+
+interface GraphyBoard {
+  id: string;
+  title: string;
+  type: string;
+  description?: string;
+  created_at: string;
+  updated_at: string;
+  is_public: boolean;
+  embed_url?: string;
+  data_source?: {
+    type: string;
+    url?: string;
+    query?: string;
+  };
+}
+
+interface GraphyDataset {
+  id: string;
+  name: string;
+  description?: string;
+  columns: Array<{
+    name: string;
+    type: string;
+    nullable: boolean;
+  }>;
+  row_count: number;
+  created_at: string;
+  updated_at: string;
+}
+
+class GraphyClient {
+  private headers: {
+    Authorization: string;
+    'Content-Type': string;
+    Accept: string;
+  };
+
+  constructor(apiToken: string) {
+    this.headers = {
+      Authorization: `Bearer ${apiToken}`,
+      'Content-Type': 'application/json',
+      Accept: 'application/json',
+    };
+  }
+
+  private async makeRequest(
+    path: string,
+    method = 'GET',
+    body?: Record<string, unknown>
+  ): Promise<unknown> {
+    const options: RequestInit = {
+      method,
+      headers: this.headers,
+    };
+
+    if (body && method !== 'GET') {
+      options.body = JSON.stringify(body);
+    }
+
+    const response = await fetch(`${GRAPHY_API_BASE}${path}`, options);
+
+    if (!response.ok) {
+      let errorMessage = `HTTP ${response.status}: ${response.statusText}`;
+      try {
+        const errorBody = (await response.json()) as { message?: string; error?: string };
+        if (errorBody.message) {
+          errorMessage = errorBody.message;
+        }
+        if (errorBody.error) {
+          errorMessage = errorBody.error;
+        }
+      } catch {
+        // If we can't parse the error, use the basic message
+      }
+      throw new Error(errorMessage);
+    }
+
+    const contentType = response.headers.get('content-type');
+    if (contentType?.includes('application/json')) {
+      return response.json();
+    }
+    return response.text();
+  }
+
+  async getBoards(limit = 50, offset = 0): Promise<GraphyBoard[]> {
+    const params = new URLSearchParams({
+      limit: limit.toString(),
+      offset: offset.toString(),
+    });
+
+    const response = await this.makeRequest(`/boards?${params}`);
+    if (typeof response === 'object' && response && 'results' in response) {
+      return response.results as GraphyBoard[];
+    }
+    return Array.isArray(response) ? response : [];
+  }
+
+  async getBoard(boardId: string): Promise<GraphyBoard> {
+    const response = await this.makeRequest(`/boards/${boardId}`);
+    if (typeof response === 'object' && response && 'data' in response) {
+      return response.data as GraphyBoard;
+    }
+    return response as GraphyBoard;
+  }
+
+  async createBoard(
+    title: string,
+    type: string,
+    description?: string,
+    datasetId?: string,
+    config?: Record<string, unknown>
+  ): Promise<GraphyBoard> {
+    const body: Record<string, unknown> = {
+      title,
+      type,
+      description,
+      dataset_id: datasetId,
+      config,
+    };
+
+    const response = await this.makeRequest('/boards', 'POST', body);
+    if (typeof response === 'object' && response && 'data' in response) {
+      return response.data as GraphyBoard;
+    }
+    return response as GraphyBoard;
+  }
+
+  async updateBoard(
+    boardId: string,
+    title?: string,
+    description?: string,
+    config?: Record<string, unknown>
+  ): Promise<GraphyBoard> {
+    const body: Record<string, unknown> = {};
+    if (title !== undefined) body.title = title;
+    if (description !== undefined) body.description = description;
+    if (config !== undefined) body.config = config;
+
+    const response = await this.makeRequest(`/boards/${boardId}`, 'PUT', body);
+    if (typeof response === 'object' && response && 'data' in response) {
+      return response.data as GraphyBoard;
+    }
+    return response as GraphyBoard;
+  }
+
+  async deleteBoard(boardId: string): Promise<boolean> {
+    await this.makeRequest(`/boards/${boardId}`, 'DELETE');
+    return true;
+  }
+
+  async getDatasets(limit = 50, offset = 0): Promise<GraphyDataset[]> {
+    const params = new URLSearchParams({
+      limit: limit.toString(),
+      offset: offset.toString(),
+    });
+
+    const response = await this.makeRequest(`/datasets?${params}`);
+    if (typeof response === 'object' && response && 'results' in response) {
+      return response.results as GraphyDataset[];
+    }
+    return Array.isArray(response) ? response : [];
+  }
+
+  async getDataset(datasetId: string): Promise<GraphyDataset> {
+    const response = await this.makeRequest(`/datasets/${datasetId}`);
+    if (typeof response === 'object' && response && 'data' in response) {
+      return response.data as GraphyDataset;
+    }
+    return response as GraphyDataset;
+  }
+
+  async createDataset(
+    name: string,
+    data: unknown[][],
+    columns: Array<{ name: string; type: string }>,
+    description?: string
+  ): Promise<GraphyDataset> {
+    const body = {
+      name,
+      description,
+      data,
+      columns,
+    };
+
+    const response = await this.makeRequest('/datasets', 'POST', body);
+    if (typeof response === 'object' && response && 'data' in response) {
+      return response.data as GraphyDataset;
+    }
+    return response as GraphyDataset;
+  }
+
+  async getBoardData(boardId: string, format = 'json'): Promise<unknown> {
+    const params = new URLSearchParams({ format });
+    return this.makeRequest(`/boards/${boardId}/data?${params}`);
+  }
+
+  async shareBoard(boardId: string, isPublic = true): Promise<string> {
+    const body = { is_public: isPublic };
+    const response = await this.makeRequest(`/boards/${boardId}/share`, 'POST', body);
+    if (typeof response === 'object' && response && 'embed_url' in response) {
+      return response.embed_url as string;
+    }
+    if (typeof response === 'object' && response && 'data' in response) {
+      const data = response.data as { embed_url?: string };
+      return data.embed_url || '';
+    }
+    return '';
+  }
+}
+
+const handleGraphyError = (error: unknown): string => {
+  if (error instanceof Error) {
+    const message = error.message.toLowerCase();
+
+    if (message.includes('unauthorized') || message.includes('401')) {
+      return 'Error: Unauthorized. Please check your Graphy API token and permissions.';
+    }
+    if (message.includes('not found') || message.includes('404')) {
+      return 'Error: API endpoint not found. The Graphy REST API may not be available yet or the endpoint path may have changed. Please check the API documentation at https://visualize.graphy.app/rest-api for the correct endpoints.';
+    }
+    if (message.includes('forbidden') || message.includes('403')) {
+      return 'Error: Access forbidden. Your API token may not have permission to access this resource.';
+    }
+    if (message.includes('rate') || message.includes('429')) {
+      return 'Error: Rate limited. Please wait before making more requests.';
+    }
+    if (message.includes('validation') || message.includes('400')) {
+      return `Error: Invalid request. ${error.message}`;
+    }
+    if (message.includes('conflict') || message.includes('409')) {
+      return "Error: Conflict. The resource you're trying to create already exists.";
+    }
+    if (message.includes('server error') || message.includes('500')) {
+      return 'Error: Internal server error. Please try again later.';
+    }
+    if (message.includes('service unavailable') || message.includes('503')) {
+      return 'Error: Service unavailable. Please try again later.';
+    }
+
+    return `Error: ${error.message}`;
+  }
+
+  return `Error: ${String(error)}`;
+};
+
+export const GraphyConnectorConfig = mcpConnectorConfig({
+  name: 'Graphy',
+  key: 'graphy',
+  version: '1.0.0',
+  logo: 'https://stackone-logos.com/api/graphy/filled/svg',
+  credentials: z.object({
+    apiToken: z
+      .string()
+      .describe(
+        'Graphy API token from your account settings :: token_1234567890abcdef :: https://visualize.graphy.app/account/api'
+      ),
+  }),
+  setup: z.object({}),
+  examplePrompt:
+    'Create a bar chart for sales data, list all my existing boards, and share a board publicly to get an embed URL.',
+  tools: (tool) => ({
+    LIST_BOARDS: tool({
+      name: 'graphy_list_boards',
+      description: 'List all boards in your Graphy account',
+      schema: z.object({
+        limit: z
+          .number()
+          .min(1)
+          .max(100)
+          .optional()
+          .default(50)
+          .describe('Number of boards to return (max 100)'),
+        offset: z
+          .number()
+          .min(0)
+          .optional()
+          .default(0)
+          .describe('Number of boards to skip for pagination'),
+      }),
+      handler: async (args, context) => {
+        try {
+          const { apiToken } = await context.getCredentials();
+          const client = new GraphyClient(apiToken);
+          const boards = await client.getBoards(args.limit, args.offset);
+          return JSON.stringify(boards, null, 2);
+        } catch (error) {
+          return handleGraphyError(error);
+        }
+      },
+    }),
+    GET_BOARD: tool({
+      name: 'graphy_get_board',
+      description: 'Get details of a specific board by ID',
+      schema: z.object({
+        boardId: z.string().describe('The ID of the board to retrieve'),
+      }),
+      handler: async (args, context) => {
+        try {
+          const { apiToken } = await context.getCredentials();
+          const client = new GraphyClient(apiToken);
+          const board = await client.getBoard(args.boardId);
+          return JSON.stringify(board, null, 2);
+        } catch (error) {
+          return handleGraphyError(error);
+        }
+      },
+    }),
+    CREATE_BOARD: tool({
+      name: 'graphy_create_board',
+      description: 'Create a new board in Graphy',
+      schema: z.object({
+        title: z.string().describe('Board title'),
+        type: z.string().describe('Board type (bar, line, pie, scatter, area, etc.)'),
+        description: z.string().optional().describe('Board description'),
+        datasetId: z.string().optional().describe('ID of dataset to use for the board'),
+        config: z.record(z.unknown()).optional().describe('Board configuration options'),
+      }),
+      handler: async (args, context) => {
+        try {
+          const { apiToken } = await context.getCredentials();
+          const client = new GraphyClient(apiToken);
+          const board = await client.createBoard(
+            args.title,
+            args.type,
+            args.description,
+            args.datasetId,
+            args.config
+          );
+          return JSON.stringify(board, null, 2);
+        } catch (error) {
+          return handleGraphyError(error);
+        }
+      },
+    }),
+    UPDATE_BOARD: tool({
+      name: 'graphy_update_board',
+      description: 'Update an existing board',
+      schema: z.object({
+        boardId: z.string().describe('The ID of the board to update'),
+        title: z.string().optional().describe('New board title'),
+        description: z.string().optional().describe('New board description'),
+        config: z
+          .record(z.unknown())
+          .optional()
+          .describe('Updated board configuration options'),
+      }),
+      handler: async (args, context) => {
+        try {
+          const { apiToken } = await context.getCredentials();
+          const client = new GraphyClient(apiToken);
+          const board = await client.updateBoard(
+            args.boardId,
+            args.title,
+            args.description,
+            args.config
+          );
+          return JSON.stringify(board, null, 2);
+        } catch (error) {
+          return handleGraphyError(error);
+        }
+      },
+    }),
+    DELETE_BOARD: tool({
+      name: 'graphy_delete_board',
+      description: 'Delete a board by ID',
+      schema: z.object({
+        boardId: z.string().describe('The ID of the board to delete'),
+      }),
+      handler: async (args, context) => {
+        try {
+          const { apiToken } = await context.getCredentials();
+          const client = new GraphyClient(apiToken);
+          await client.deleteBoard(args.boardId);
+          return `Board ${args.boardId} deleted successfully`;
+        } catch (error) {
+          return handleGraphyError(error);
+        }
+      },
+    }),
+    LIST_DATASETS: tool({
+      name: 'graphy_list_datasets',
+      description: 'List all datasets in your Graphy account',
+      schema: z.object({
+        limit: z
+          .number()
+          .min(1)
+          .max(100)
+          .optional()
+          .default(50)
+          .describe('Number of datasets to return (max 100)'),
+        offset: z
+          .number()
+          .min(0)
+          .optional()
+          .default(0)
+          .describe('Number of datasets to skip for pagination'),
+      }),
+      handler: async (args, context) => {
+        try {
+          const { apiToken } = await context.getCredentials();
+          const client = new GraphyClient(apiToken);
+          const datasets = await client.getDatasets(args.limit, args.offset);
+          return JSON.stringify(datasets, null, 2);
+        } catch (error) {
+          return handleGraphyError(error);
+        }
+      },
+    }),
+    GET_DATASET: tool({
+      name: 'graphy_get_dataset',
+      description: 'Get details of a specific dataset by ID',
+      schema: z.object({
+        datasetId: z.string().describe('The ID of the dataset to retrieve'),
+      }),
+      handler: async (args, context) => {
+        try {
+          const { apiToken } = await context.getCredentials();
+          const client = new GraphyClient(apiToken);
+          const dataset = await client.getDataset(args.datasetId);
+          return JSON.stringify(dataset, null, 2);
+        } catch (error) {
+          return handleGraphyError(error);
+        }
+      },
+    }),
+    CREATE_DATASET: tool({
+      name: 'graphy_create_dataset',
+      description: 'Create a new dataset with data',
+      schema: z.object({
+        name: z.string().describe('Dataset name'),
+        data: z.array(z.array(z.unknown())).describe('Array of data rows'),
+        columns: z
+          .array(
+            z.object({
+              name: z.string().describe('Column name'),
+              type: z
+                .string()
+                .describe('Column data type (string, number, date, boolean)'),
+            })
+          )
+          .describe('Array of column definitions'),
+        description: z.string().optional().describe('Dataset description'),
+      }),
+      handler: async (args, context) => {
+        try {
+          const { apiToken } = await context.getCredentials();
+          const client = new GraphyClient(apiToken);
+          const dataset = await client.createDataset(
+            args.name,
+            args.data,
+            args.columns,
+            args.description
+          );
+          return JSON.stringify(dataset, null, 2);
+        } catch (error) {
+          return handleGraphyError(error);
+        }
+      },
+    }),
+    GET_BOARD_DATA: tool({
+      name: 'graphy_get_board_data',
+      description: 'Get the underlying data for a board',
+      schema: z.object({
+        boardId: z.string().describe('The ID of the board to get data for'),
+        format: z
+          .enum(['json', 'csv', 'xlsx'])
+          .optional()
+          .default('json')
+          .describe('Data format to return'),
+      }),
+      handler: async (args, context) => {
+        try {
+          const { apiToken } = await context.getCredentials();
+          const client = new GraphyClient(apiToken);
+          const data = await client.getBoardData(args.boardId, args.format);
+          if (args.format === 'json') {
+            return JSON.stringify(data, null, 2);
+          }
+          return String(data);
+        } catch (error) {
+          return handleGraphyError(error);
+        }
+      },
+    }),
+    SHARE_BOARD: tool({
+      name: 'graphy_share_board',
+      description: 'Share a board publicly and get an embed URL',
+      schema: z.object({
+        boardId: z.string().describe('The ID of the board to share'),
+        isPublic: z
+          .boolean()
+          .optional()
+          .default(true)
+          .describe('Whether to make the board publicly accessible'),
+      }),
+      handler: async (args, context) => {
+        try {
+          const { apiToken } = await context.getCredentials();
+          const client = new GraphyClient(apiToken);
+          const embedUrl = await client.shareBoard(args.boardId, args.isPublic);
+          return `Board shared successfully. Embed URL: ${embedUrl}`;
+        } catch (error) {
+          return handleGraphyError(error);
+        }
+      },
+    }),
+  }),
+});

--- a/packages/mcp-connectors/src/connectors/graphy.ts
+++ b/packages/mcp-connectors/src/connectors/graphy.ts
@@ -1,513 +1,528 @@
-import { mcpConnectorConfig } from '@stackone/mcp-config-types';
-import { z } from 'zod';
+import { mcpConnectorConfig } from "@stackone/mcp-config-types";
+import { z } from "zod";
 
-const GRAPHY_API_BASE = 'https://api.graphy.app/rest/v1';
+const GRAPHY_API_BASE = "https://api.graphy.app/rest/v1";
 
 interface GraphyBoard {
-  id: string;
-  title: string;
-  type: string;
-  description?: string;
-  created_at: string;
-  updated_at: string;
-  is_public: boolean;
-  embed_url?: string;
-  data_source?: {
-    type: string;
-    url?: string;
-    query?: string;
-  };
+	id: string;
+	title: string;
+	type: string;
+	description?: string;
+	created_at: string;
+	updated_at: string;
+	is_public: boolean;
+	embed_url?: string;
+	data_source?: {
+		type: string;
+		url?: string;
+		query?: string;
+	};
 }
 
 interface GraphyDataset {
-  id: string;
-  name: string;
-  description?: string;
-  columns: Array<{
-    name: string;
-    type: string;
-    nullable: boolean;
-  }>;
-  row_count: number;
-  created_at: string;
-  updated_at: string;
+	id: string;
+	name: string;
+	description?: string;
+	columns: Array<{
+		name: string;
+		type: string;
+		nullable: boolean;
+	}>;
+	row_count: number;
+	created_at: string;
+	updated_at: string;
 }
 
 class GraphyClient {
-  private headers: {
-    Authorization: string;
-    'Content-Type': string;
-    Accept: string;
-  };
+	private headers: {
+		Authorization: string;
+		"Content-Type": string;
+		Accept: string;
+	};
 
-  constructor(apiToken: string) {
-    this.headers = {
-      Authorization: `Bearer ${apiToken}`,
-      'Content-Type': 'application/json',
-      Accept: 'application/json',
-    };
-  }
+	constructor(apiToken: string) {
+		this.headers = {
+			Authorization: `Bearer ${apiToken}`,
+			"Content-Type": "application/json",
+			Accept: "application/json",
+		};
+	}
 
-  private async makeRequest(
-    path: string,
-    method = 'GET',
-    body?: Record<string, unknown>
-  ): Promise<unknown> {
-    const options: RequestInit = {
-      method,
-      headers: this.headers,
-    };
+	private async makeRequest(
+		path: string,
+		method = "GET",
+		body?: Record<string, unknown>,
+	): Promise<unknown> {
+		const options: RequestInit = {
+			method,
+			headers: this.headers,
+		};
 
-    if (body && method !== 'GET') {
-      options.body = JSON.stringify(body);
-    }
+		if (body && method !== "GET") {
+			options.body = JSON.stringify(body);
+		}
 
-    const response = await fetch(`${GRAPHY_API_BASE}${path}`, options);
+		const response = await fetch(`${GRAPHY_API_BASE}${path}`, options);
 
-    if (!response.ok) {
-      let errorMessage = `HTTP ${response.status}: ${response.statusText}`;
-      try {
-        const errorBody = (await response.json()) as { message?: string; error?: string };
-        if (errorBody.message) {
-          errorMessage = errorBody.message;
-        }
-        if (errorBody.error) {
-          errorMessage = errorBody.error;
-        }
-      } catch {
-        // If we can't parse the error, use the basic message
-      }
-      throw new Error(errorMessage);
-    }
+		if (!response.ok) {
+			let errorMessage = `HTTP ${response.status}: ${response.statusText}`;
+			try {
+				const errorBody = (await response.json()) as {
+					message?: string;
+					error?: string;
+				};
+				if (errorBody.message) {
+					errorMessage = errorBody.message;
+				}
+				if (errorBody.error) {
+					errorMessage = errorBody.error;
+				}
+			} catch {
+				// If we can't parse the error, use the basic message
+			}
+			throw new Error(errorMessage);
+		}
 
-    const contentType = response.headers.get('content-type');
-    if (contentType?.includes('application/json')) {
-      return response.json();
-    }
-    return response.text();
-  }
+		const contentType = response.headers.get("content-type");
+		if (contentType?.includes("application/json")) {
+			return response.json();
+		}
+		return response.text();
+	}
 
-  async getBoards(limit = 50, offset = 0): Promise<GraphyBoard[]> {
-    const params = new URLSearchParams({
-      limit: limit.toString(),
-      offset: offset.toString(),
-    });
+	async getBoards(limit = 50, offset = 0): Promise<GraphyBoard[]> {
+		const params = new URLSearchParams({
+			limit: limit.toString(),
+			offset: offset.toString(),
+		});
 
-    const response = await this.makeRequest(`/boards?${params}`);
-    if (typeof response === 'object' && response && 'results' in response) {
-      return response.results as GraphyBoard[];
-    }
-    return Array.isArray(response) ? response : [];
-  }
+		const response = await this.makeRequest(`/boards?${params}`);
+		if (typeof response === "object" && response && "results" in response) {
+			return response.results as GraphyBoard[];
+		}
+		return Array.isArray(response) ? response : [];
+	}
 
-  async getBoard(boardId: string): Promise<GraphyBoard> {
-    const response = await this.makeRequest(`/boards/${boardId}`);
-    if (typeof response === 'object' && response && 'data' in response) {
-      return response.data as GraphyBoard;
-    }
-    return response as GraphyBoard;
-  }
+	async getBoard(boardId: string): Promise<GraphyBoard> {
+		const response = await this.makeRequest(`/boards/${boardId}`);
+		if (typeof response === "object" && response && "data" in response) {
+			return response.data as GraphyBoard;
+		}
+		return response as GraphyBoard;
+	}
 
-  async createBoard(
-    title: string,
-    type: string,
-    description?: string,
-    datasetId?: string,
-    config?: Record<string, unknown>
-  ): Promise<GraphyBoard> {
-    const body: Record<string, unknown> = {
-      title,
-      type,
-      description,
-      dataset_id: datasetId,
-      config,
-    };
+	async createBoard(
+		title: string,
+		type: string,
+		description?: string,
+		datasetId?: string,
+		config?: Record<string, unknown>,
+	): Promise<GraphyBoard> {
+		const body: Record<string, unknown> = {
+			title,
+			type,
+			description,
+			dataset_id: datasetId,
+			config,
+		};
 
-    const response = await this.makeRequest('/boards', 'POST', body);
-    if (typeof response === 'object' && response && 'data' in response) {
-      return response.data as GraphyBoard;
-    }
-    return response as GraphyBoard;
-  }
+		const response = await this.makeRequest("/boards", "POST", body);
+		if (typeof response === "object" && response && "data" in response) {
+			return response.data as GraphyBoard;
+		}
+		return response as GraphyBoard;
+	}
 
-  async updateBoard(
-    boardId: string,
-    title?: string,
-    description?: string,
-    config?: Record<string, unknown>
-  ): Promise<GraphyBoard> {
-    const body: Record<string, unknown> = {};
-    if (title !== undefined) body.title = title;
-    if (description !== undefined) body.description = description;
-    if (config !== undefined) body.config = config;
+	async updateBoard(
+		boardId: string,
+		title?: string,
+		description?: string,
+		config?: Record<string, unknown>,
+	): Promise<GraphyBoard> {
+		const body: Record<string, unknown> = {};
+		if (title !== undefined) body.title = title;
+		if (description !== undefined) body.description = description;
+		if (config !== undefined) body.config = config;
 
-    const response = await this.makeRequest(`/boards/${boardId}`, 'PUT', body);
-    if (typeof response === 'object' && response && 'data' in response) {
-      return response.data as GraphyBoard;
-    }
-    return response as GraphyBoard;
-  }
+		const response = await this.makeRequest(`/boards/${boardId}`, "PUT", body);
+		if (typeof response === "object" && response && "data" in response) {
+			return response.data as GraphyBoard;
+		}
+		return response as GraphyBoard;
+	}
 
-  async deleteBoard(boardId: string): Promise<boolean> {
-    await this.makeRequest(`/boards/${boardId}`, 'DELETE');
-    return true;
-  }
+	async deleteBoard(boardId: string): Promise<boolean> {
+		await this.makeRequest(`/boards/${boardId}`, "DELETE");
+		return true;
+	}
 
-  async getDatasets(limit = 50, offset = 0): Promise<GraphyDataset[]> {
-    const params = new URLSearchParams({
-      limit: limit.toString(),
-      offset: offset.toString(),
-    });
+	async getDatasets(limit = 50, offset = 0): Promise<GraphyDataset[]> {
+		const params = new URLSearchParams({
+			limit: limit.toString(),
+			offset: offset.toString(),
+		});
 
-    const response = await this.makeRequest(`/datasets?${params}`);
-    if (typeof response === 'object' && response && 'results' in response) {
-      return response.results as GraphyDataset[];
-    }
-    return Array.isArray(response) ? response : [];
-  }
+		const response = await this.makeRequest(`/datasets?${params}`);
+		if (typeof response === "object" && response && "results" in response) {
+			return response.results as GraphyDataset[];
+		}
+		return Array.isArray(response) ? response : [];
+	}
 
-  async getDataset(datasetId: string): Promise<GraphyDataset> {
-    const response = await this.makeRequest(`/datasets/${datasetId}`);
-    if (typeof response === 'object' && response && 'data' in response) {
-      return response.data as GraphyDataset;
-    }
-    return response as GraphyDataset;
-  }
+	async getDataset(datasetId: string): Promise<GraphyDataset> {
+		const response = await this.makeRequest(`/datasets/${datasetId}`);
+		if (typeof response === "object" && response && "data" in response) {
+			return response.data as GraphyDataset;
+		}
+		return response as GraphyDataset;
+	}
 
-  async createDataset(
-    name: string,
-    data: unknown[][],
-    columns: Array<{ name: string; type: string }>,
-    description?: string
-  ): Promise<GraphyDataset> {
-    const body = {
-      name,
-      description,
-      data,
-      columns,
-    };
+	async createDataset(
+		name: string,
+		data: unknown[][],
+		columns: Array<{ name: string; type: string }>,
+		description?: string,
+	): Promise<GraphyDataset> {
+		const body = {
+			name,
+			description,
+			data,
+			columns,
+		};
 
-    const response = await this.makeRequest('/datasets', 'POST', body);
-    if (typeof response === 'object' && response && 'data' in response) {
-      return response.data as GraphyDataset;
-    }
-    return response as GraphyDataset;
-  }
+		const response = await this.makeRequest("/datasets", "POST", body);
+		if (typeof response === "object" && response && "data" in response) {
+			return response.data as GraphyDataset;
+		}
+		return response as GraphyDataset;
+	}
 
-  async getBoardData(boardId: string, format = 'json'): Promise<unknown> {
-    const params = new URLSearchParams({ format });
-    return this.makeRequest(`/boards/${boardId}/data?${params}`);
-  }
+	async getBoardData(boardId: string, format = "json"): Promise<unknown> {
+		const params = new URLSearchParams({ format });
+		return this.makeRequest(`/boards/${boardId}/data?${params}`);
+	}
 
-  async shareBoard(boardId: string, isPublic = true): Promise<string> {
-    const body = { is_public: isPublic };
-    const response = await this.makeRequest(`/boards/${boardId}/share`, 'POST', body);
-    if (typeof response === 'object' && response && 'embed_url' in response) {
-      return response.embed_url as string;
-    }
-    if (typeof response === 'object' && response && 'data' in response) {
-      const data = response.data as { embed_url?: string };
-      return data.embed_url || '';
-    }
-    return '';
-  }
+	async shareBoard(boardId: string, isPublic = true): Promise<string> {
+		const body = { is_public: isPublic };
+		const response = await this.makeRequest(
+			`/boards/${boardId}/share`,
+			"POST",
+			body,
+		);
+		if (typeof response === "object" && response && "embed_url" in response) {
+			return response.embed_url as string;
+		}
+		if (typeof response === "object" && response && "data" in response) {
+			const data = response.data as { embed_url?: string };
+			return data.embed_url || "";
+		}
+		return "";
+	}
 }
 
 const handleGraphyError = (error: unknown): string => {
-  if (error instanceof Error) {
-    const message = error.message.toLowerCase();
+	if (error instanceof Error) {
+		const message = error.message.toLowerCase();
 
-    if (message.includes('unauthorized') || message.includes('401')) {
-      return 'Error: Unauthorized. Please check your Graphy API token and permissions.';
-    }
-    if (message.includes('not found') || message.includes('404')) {
-      return 'Error: API endpoint not found. The Graphy REST API may not be available yet or the endpoint path may have changed. Please check the API documentation at https://visualize.graphy.app/rest-api for the correct endpoints.';
-    }
-    if (message.includes('forbidden') || message.includes('403')) {
-      return 'Error: Access forbidden. Your API token may not have permission to access this resource.';
-    }
-    if (message.includes('rate') || message.includes('429')) {
-      return 'Error: Rate limited. Please wait before making more requests.';
-    }
-    if (message.includes('validation') || message.includes('400')) {
-      return `Error: Invalid request. ${error.message}`;
-    }
-    if (message.includes('conflict') || message.includes('409')) {
-      return "Error: Conflict. The resource you're trying to create already exists.";
-    }
-    if (message.includes('server error') || message.includes('500')) {
-      return 'Error: Internal server error. Please try again later.';
-    }
-    if (message.includes('service unavailable') || message.includes('503')) {
-      return 'Error: Service unavailable. Please try again later.';
-    }
+		if (message.includes("unauthorized") || message.includes("401")) {
+			return "Error: Unauthorized. Please check your Graphy API token and permissions.";
+		}
+		if (message.includes("not found") || message.includes("404")) {
+			return "Error: API endpoint not found. The Graphy REST API may not be available yet or the endpoint path may have changed. Please check the API documentation at https://visualize.graphy.app/rest-api for the correct endpoints.";
+		}
+		if (message.includes("forbidden") || message.includes("403")) {
+			return "Error: Access forbidden. Your API token may not have permission to access this resource.";
+		}
+		if (message.includes("rate") || message.includes("429")) {
+			return "Error: Rate limited. Please wait before making more requests.";
+		}
+		if (message.includes("validation") || message.includes("400")) {
+			return `Error: Invalid request. ${error.message}`;
+		}
+		if (message.includes("conflict") || message.includes("409")) {
+			return "Error: Conflict. The resource you're trying to create already exists.";
+		}
+		if (message.includes("server error") || message.includes("500")) {
+			return "Error: Internal server error. Please try again later.";
+		}
+		if (message.includes("service unavailable") || message.includes("503")) {
+			return "Error: Service unavailable. Please try again later.";
+		}
 
-    return `Error: ${error.message}`;
-  }
+		return `Error: ${error.message}`;
+	}
 
-  return `Error: ${String(error)}`;
+	return `Error: ${String(error)}`;
 };
 
 export const GraphyConnectorConfig = mcpConnectorConfig({
-  name: 'Graphy',
-  key: 'graphy',
-  version: '1.0.0',
-  logo: 'https://stackone-logos.com/api/graphy/filled/svg',
-  credentials: z.object({
-    apiToken: z
-      .string()
-      .describe(
-        'Graphy API token from your account settings :: token_1234567890abcdef :: https://visualize.graphy.app/account/api'
-      ),
-  }),
-  setup: z.object({}),
-  examplePrompt:
-    'Create a bar chart for sales data, list all my existing boards, and share a board publicly to get an embed URL.',
-  tools: (tool) => ({
-    LIST_BOARDS: tool({
-      name: 'graphy_list_boards',
-      description: 'List all boards in your Graphy account',
-      schema: z.object({
-        limit: z
-          .number()
-          .min(1)
-          .max(100)
-          .optional()
-          .default(50)
-          .describe('Number of boards to return (max 100)'),
-        offset: z
-          .number()
-          .min(0)
-          .optional()
-          .default(0)
-          .describe('Number of boards to skip for pagination'),
-      }),
-      handler: async (args, context) => {
-        try {
-          const { apiToken } = await context.getCredentials();
-          const client = new GraphyClient(apiToken);
-          const boards = await client.getBoards(args.limit, args.offset);
-          return JSON.stringify(boards, null, 2);
-        } catch (error) {
-          return handleGraphyError(error);
-        }
-      },
-    }),
-    GET_BOARD: tool({
-      name: 'graphy_get_board',
-      description: 'Get details of a specific board by ID',
-      schema: z.object({
-        boardId: z.string().describe('The ID of the board to retrieve'),
-      }),
-      handler: async (args, context) => {
-        try {
-          const { apiToken } = await context.getCredentials();
-          const client = new GraphyClient(apiToken);
-          const board = await client.getBoard(args.boardId);
-          return JSON.stringify(board, null, 2);
-        } catch (error) {
-          return handleGraphyError(error);
-        }
-      },
-    }),
-    CREATE_BOARD: tool({
-      name: 'graphy_create_board',
-      description: 'Create a new board in Graphy',
-      schema: z.object({
-        title: z.string().describe('Board title'),
-        type: z.string().describe('Board type (bar, line, pie, scatter, area, etc.)'),
-        description: z.string().optional().describe('Board description'),
-        datasetId: z.string().optional().describe('ID of dataset to use for the board'),
-        config: z.record(z.unknown()).optional().describe('Board configuration options'),
-      }),
-      handler: async (args, context) => {
-        try {
-          const { apiToken } = await context.getCredentials();
-          const client = new GraphyClient(apiToken);
-          const board = await client.createBoard(
-            args.title,
-            args.type,
-            args.description,
-            args.datasetId,
-            args.config
-          );
-          return JSON.stringify(board, null, 2);
-        } catch (error) {
-          return handleGraphyError(error);
-        }
-      },
-    }),
-    UPDATE_BOARD: tool({
-      name: 'graphy_update_board',
-      description: 'Update an existing board',
-      schema: z.object({
-        boardId: z.string().describe('The ID of the board to update'),
-        title: z.string().optional().describe('New board title'),
-        description: z.string().optional().describe('New board description'),
-        config: z
-          .record(z.unknown())
-          .optional()
-          .describe('Updated board configuration options'),
-      }),
-      handler: async (args, context) => {
-        try {
-          const { apiToken } = await context.getCredentials();
-          const client = new GraphyClient(apiToken);
-          const board = await client.updateBoard(
-            args.boardId,
-            args.title,
-            args.description,
-            args.config
-          );
-          return JSON.stringify(board, null, 2);
-        } catch (error) {
-          return handleGraphyError(error);
-        }
-      },
-    }),
-    DELETE_BOARD: tool({
-      name: 'graphy_delete_board',
-      description: 'Delete a board by ID',
-      schema: z.object({
-        boardId: z.string().describe('The ID of the board to delete'),
-      }),
-      handler: async (args, context) => {
-        try {
-          const { apiToken } = await context.getCredentials();
-          const client = new GraphyClient(apiToken);
-          await client.deleteBoard(args.boardId);
-          return `Board ${args.boardId} deleted successfully`;
-        } catch (error) {
-          return handleGraphyError(error);
-        }
-      },
-    }),
-    LIST_DATASETS: tool({
-      name: 'graphy_list_datasets',
-      description: 'List all datasets in your Graphy account',
-      schema: z.object({
-        limit: z
-          .number()
-          .min(1)
-          .max(100)
-          .optional()
-          .default(50)
-          .describe('Number of datasets to return (max 100)'),
-        offset: z
-          .number()
-          .min(0)
-          .optional()
-          .default(0)
-          .describe('Number of datasets to skip for pagination'),
-      }),
-      handler: async (args, context) => {
-        try {
-          const { apiToken } = await context.getCredentials();
-          const client = new GraphyClient(apiToken);
-          const datasets = await client.getDatasets(args.limit, args.offset);
-          return JSON.stringify(datasets, null, 2);
-        } catch (error) {
-          return handleGraphyError(error);
-        }
-      },
-    }),
-    GET_DATASET: tool({
-      name: 'graphy_get_dataset',
-      description: 'Get details of a specific dataset by ID',
-      schema: z.object({
-        datasetId: z.string().describe('The ID of the dataset to retrieve'),
-      }),
-      handler: async (args, context) => {
-        try {
-          const { apiToken } = await context.getCredentials();
-          const client = new GraphyClient(apiToken);
-          const dataset = await client.getDataset(args.datasetId);
-          return JSON.stringify(dataset, null, 2);
-        } catch (error) {
-          return handleGraphyError(error);
-        }
-      },
-    }),
-    CREATE_DATASET: tool({
-      name: 'graphy_create_dataset',
-      description: 'Create a new dataset with data',
-      schema: z.object({
-        name: z.string().describe('Dataset name'),
-        data: z.array(z.array(z.unknown())).describe('Array of data rows'),
-        columns: z
-          .array(
-            z.object({
-              name: z.string().describe('Column name'),
-              type: z
-                .string()
-                .describe('Column data type (string, number, date, boolean)'),
-            })
-          )
-          .describe('Array of column definitions'),
-        description: z.string().optional().describe('Dataset description'),
-      }),
-      handler: async (args, context) => {
-        try {
-          const { apiToken } = await context.getCredentials();
-          const client = new GraphyClient(apiToken);
-          const dataset = await client.createDataset(
-            args.name,
-            args.data,
-            args.columns,
-            args.description
-          );
-          return JSON.stringify(dataset, null, 2);
-        } catch (error) {
-          return handleGraphyError(error);
-        }
-      },
-    }),
-    GET_BOARD_DATA: tool({
-      name: 'graphy_get_board_data',
-      description: 'Get the underlying data for a board',
-      schema: z.object({
-        boardId: z.string().describe('The ID of the board to get data for'),
-        format: z
-          .enum(['json', 'csv', 'xlsx'])
-          .optional()
-          .default('json')
-          .describe('Data format to return'),
-      }),
-      handler: async (args, context) => {
-        try {
-          const { apiToken } = await context.getCredentials();
-          const client = new GraphyClient(apiToken);
-          const data = await client.getBoardData(args.boardId, args.format);
-          if (args.format === 'json') {
-            return JSON.stringify(data, null, 2);
-          }
-          return String(data);
-        } catch (error) {
-          return handleGraphyError(error);
-        }
-      },
-    }),
-    SHARE_BOARD: tool({
-      name: 'graphy_share_board',
-      description: 'Share a board publicly and get an embed URL',
-      schema: z.object({
-        boardId: z.string().describe('The ID of the board to share'),
-        isPublic: z
-          .boolean()
-          .optional()
-          .default(true)
-          .describe('Whether to make the board publicly accessible'),
-      }),
-      handler: async (args, context) => {
-        try {
-          const { apiToken } = await context.getCredentials();
-          const client = new GraphyClient(apiToken);
-          const embedUrl = await client.shareBoard(args.boardId, args.isPublic);
-          return `Board shared successfully. Embed URL: ${embedUrl}`;
-        } catch (error) {
-          return handleGraphyError(error);
-        }
-      },
-    }),
-  }),
+	name: "Graphy",
+	key: "graphy",
+	version: "1.0.0",
+	logo: "https://stackone-logos.com/api/graphy/filled/svg",
+	credentials: z.object({
+		apiToken: z
+			.string()
+			.describe(
+				"Graphy API token from your account settings :: token_1234567890abcdef :: https://visualize.graphy.app/account/api",
+			),
+	}),
+	setup: z.object({}),
+	examplePrompt:
+		"Create a bar chart for sales data, list all my existing boards, and share a board publicly to get an embed URL. Show me all my datasets and create a line chart from the revenue dataset to visualize monthly trends. Create a pie chart showing user distribution by country from my analytics dataset, then share it publicly.",
+	tools: (tool) => ({
+		LIST_BOARDS: tool({
+			name: "graphy_list_boards",
+			description: "List all boards in your Graphy account",
+			schema: z.object({
+				limit: z
+					.number()
+					.min(1)
+					.max(100)
+					.optional()
+					.default(50)
+					.describe("Number of boards to return (max 100)"),
+				offset: z
+					.number()
+					.min(0)
+					.optional()
+					.default(0)
+					.describe("Number of boards to skip for pagination"),
+			}),
+			handler: async (args, context) => {
+				try {
+					const { apiToken } = await context.getCredentials();
+					const client = new GraphyClient(apiToken);
+					const boards = await client.getBoards(args.limit, args.offset);
+					return JSON.stringify(boards, null, 2);
+				} catch (error) {
+					return handleGraphyError(error);
+				}
+			},
+		}),
+		GET_BOARD: tool({
+			name: "graphy_get_board",
+			description: "Get details of a specific board by ID",
+			schema: z.object({
+				boardId: z.string().describe("The ID of the board to retrieve"),
+			}),
+			handler: async (args, context) => {
+				try {
+					const { apiToken } = await context.getCredentials();
+					const client = new GraphyClient(apiToken);
+					const board = await client.getBoard(args.boardId);
+					return JSON.stringify(board, null, 2);
+				} catch (error) {
+					return handleGraphyError(error);
+				}
+			},
+		}),
+		CREATE_BOARD: tool({
+			name: "graphy_create_board",
+			description: "Create a new board in Graphy",
+			schema: z.object({
+				title: z.string().describe("Board title"),
+				type: z
+					.string()
+					.describe("Board type (bar, line, pie, scatter, area, etc.)"),
+				description: z.string().optional().describe("Board description"),
+				datasetId: z
+					.string()
+					.optional()
+					.describe("ID of dataset to use for the board"),
+				config: z
+					.record(z.unknown())
+					.optional()
+					.describe("Board configuration options"),
+			}),
+			handler: async (args, context) => {
+				try {
+					const { apiToken } = await context.getCredentials();
+					const client = new GraphyClient(apiToken);
+					const board = await client.createBoard(
+						args.title,
+						args.type,
+						args.description,
+						args.datasetId,
+						args.config,
+					);
+					return JSON.stringify(board, null, 2);
+				} catch (error) {
+					return handleGraphyError(error);
+				}
+			},
+		}),
+		UPDATE_BOARD: tool({
+			name: "graphy_update_board",
+			description: "Update an existing board",
+			schema: z.object({
+				boardId: z.string().describe("The ID of the board to update"),
+				title: z.string().optional().describe("New board title"),
+				description: z.string().optional().describe("New board description"),
+				config: z
+					.record(z.unknown())
+					.optional()
+					.describe("Updated board configuration options"),
+			}),
+			handler: async (args, context) => {
+				try {
+					const { apiToken } = await context.getCredentials();
+					const client = new GraphyClient(apiToken);
+					const board = await client.updateBoard(
+						args.boardId,
+						args.title,
+						args.description,
+						args.config,
+					);
+					return JSON.stringify(board, null, 2);
+				} catch (error) {
+					return handleGraphyError(error);
+				}
+			},
+		}),
+		DELETE_BOARD: tool({
+			name: "graphy_delete_board",
+			description: "Delete a board by ID",
+			schema: z.object({
+				boardId: z.string().describe("The ID of the board to delete"),
+			}),
+			handler: async (args, context) => {
+				try {
+					const { apiToken } = await context.getCredentials();
+					const client = new GraphyClient(apiToken);
+					await client.deleteBoard(args.boardId);
+					return `Board ${args.boardId} deleted successfully`;
+				} catch (error) {
+					return handleGraphyError(error);
+				}
+			},
+		}),
+		LIST_DATASETS: tool({
+			name: "graphy_list_datasets",
+			description: "List all datasets in your Graphy account",
+			schema: z.object({
+				limit: z
+					.number()
+					.min(1)
+					.max(100)
+					.optional()
+					.default(50)
+					.describe("Number of datasets to return (max 100)"),
+				offset: z
+					.number()
+					.min(0)
+					.optional()
+					.default(0)
+					.describe("Number of datasets to skip for pagination"),
+			}),
+			handler: async (args, context) => {
+				try {
+					const { apiToken } = await context.getCredentials();
+					const client = new GraphyClient(apiToken);
+					const datasets = await client.getDatasets(args.limit, args.offset);
+					return JSON.stringify(datasets, null, 2);
+				} catch (error) {
+					return handleGraphyError(error);
+				}
+			},
+		}),
+		GET_DATASET: tool({
+			name: "graphy_get_dataset",
+			description: "Get details of a specific dataset by ID",
+			schema: z.object({
+				datasetId: z.string().describe("The ID of the dataset to retrieve"),
+			}),
+			handler: async (args, context) => {
+				try {
+					const { apiToken } = await context.getCredentials();
+					const client = new GraphyClient(apiToken);
+					const dataset = await client.getDataset(args.datasetId);
+					return JSON.stringify(dataset, null, 2);
+				} catch (error) {
+					return handleGraphyError(error);
+				}
+			},
+		}),
+		CREATE_DATASET: tool({
+			name: "graphy_create_dataset",
+			description: "Create a new dataset with data",
+			schema: z.object({
+				name: z.string().describe("Dataset name"),
+				data: z.array(z.array(z.unknown())).describe("Array of data rows"),
+				columns: z
+					.array(
+						z.object({
+							name: z.string().describe("Column name"),
+							type: z
+								.string()
+								.describe("Column data type (string, number, date, boolean)"),
+						}),
+					)
+					.describe("Array of column definitions"),
+				description: z.string().optional().describe("Dataset description"),
+			}),
+			handler: async (args, context) => {
+				try {
+					const { apiToken } = await context.getCredentials();
+					const client = new GraphyClient(apiToken);
+					const dataset = await client.createDataset(
+						args.name,
+						args.data,
+						args.columns,
+						args.description,
+					);
+					return JSON.stringify(dataset, null, 2);
+				} catch (error) {
+					return handleGraphyError(error);
+				}
+			},
+		}),
+		GET_BOARD_DATA: tool({
+			name: "graphy_get_board_data",
+			description: "Get the underlying data for a board",
+			schema: z.object({
+				boardId: z.string().describe("The ID of the board to get data for"),
+				format: z
+					.enum(["json", "csv", "xlsx"])
+					.optional()
+					.default("json")
+					.describe("Data format to return"),
+			}),
+			handler: async (args, context) => {
+				try {
+					const { apiToken } = await context.getCredentials();
+					const client = new GraphyClient(apiToken);
+					const data = await client.getBoardData(args.boardId, args.format);
+					if (args.format === "json") {
+						return JSON.stringify(data, null, 2);
+					}
+					return String(data);
+				} catch (error) {
+					return handleGraphyError(error);
+				}
+			},
+		}),
+		SHARE_BOARD: tool({
+			name: "graphy_share_board",
+			description: "Share a board publicly and get an embed URL",
+			schema: z.object({
+				boardId: z.string().describe("The ID of the board to share"),
+				isPublic: z
+					.boolean()
+					.optional()
+					.default(true)
+					.describe("Whether to make the board publicly accessible"),
+			}),
+			handler: async (args, context) => {
+				try {
+					const { apiToken } = await context.getCredentials();
+					const client = new GraphyClient(apiToken);
+					const embedUrl = await client.shareBoard(args.boardId, args.isPublic);
+					return `Board shared successfully. Embed URL: ${embedUrl}`;
+				} catch (error) {
+					return handleGraphyError(error);
+				}
+			},
+		}),
+	}),
 });

--- a/packages/mcp-connectors/src/connectors/graphy.ts
+++ b/packages/mcp-connectors/src/connectors/graphy.ts
@@ -227,7 +227,7 @@ export const GraphyConnectorConfig = mcpConnectorConfig({
   name: 'Graphy',
   key: 'graphy',
   version: '1.0.0',
-  logo: 'https://stackone-logos.com/api/graphy/filled/svg',
+  logo: 'https://stackone-logos.com/api/graphy/squared/png',
   credentials: z.object({
     apiToken: z
       .string()

--- a/packages/mcp-connectors/src/connectors/graphy.ts
+++ b/packages/mcp-connectors/src/connectors/graphy.ts
@@ -1,528 +1,488 @@
-import { mcpConnectorConfig } from "@stackone/mcp-config-types";
-import { z } from "zod";
+import { mcpConnectorConfig } from '@stackone/mcp-config-types';
+import { z } from 'zod';
 
-const GRAPHY_API_BASE = "https://api.graphy.app/rest/v1";
+const GRAPHY_API_BASE = 'https://api.graphy.app/rest/v1';
 
 interface GraphyBoard {
-	id: string;
-	title: string;
-	type: string;
-	description?: string;
-	created_at: string;
-	updated_at: string;
-	is_public: boolean;
-	embed_url?: string;
-	data_source?: {
-		type: string;
-		url?: string;
-		query?: string;
-	};
+  id: string;
+  title: string;
+  type: string;
+  description?: string;
+  created_at: string;
+  updated_at: string;
+  is_public: boolean;
+  embed_url?: string;
+  data_source?: {
+    type: string;
+    url?: string;
+    query?: string;
+  };
 }
 
 interface GraphyDataset {
-	id: string;
-	name: string;
-	description?: string;
-	columns: Array<{
-		name: string;
-		type: string;
-		nullable: boolean;
-	}>;
-	row_count: number;
-	created_at: string;
-	updated_at: string;
+  id: string;
+  name: string;
+  description?: string;
+  columns: Array<{
+    name: string;
+    type: string;
+    nullable: boolean;
+  }>;
+  row_count: number;
+  created_at: string;
+  updated_at: string;
 }
 
 class GraphyClient {
-	private headers: {
-		Authorization: string;
-		"Content-Type": string;
-		Accept: string;
-	};
+  private headers: {
+    Authorization: string;
+    'Content-Type': string;
+    Accept: string;
+  };
 
-	constructor(apiToken: string) {
-		this.headers = {
-			Authorization: `Bearer ${apiToken}`,
-			"Content-Type": "application/json",
-			Accept: "application/json",
-		};
-	}
+  constructor(apiToken: string) {
+    this.headers = {
+      Authorization: `Bearer ${apiToken}`,
+      'Content-Type': 'application/json',
+      Accept: 'application/json',
+    };
+  }
 
-	private async makeRequest(
-		path: string,
-		method = "GET",
-		body?: Record<string, unknown>,
-	): Promise<unknown> {
-		const options: RequestInit = {
-			method,
-			headers: this.headers,
-		};
+  private async makeRequest(
+    path: string,
+    method = 'GET',
+    body?: Record<string, unknown>
+  ): Promise<unknown> {
+    const options: RequestInit = {
+      method,
+      headers: this.headers,
+    };
 
-		if (body && method !== "GET") {
-			options.body = JSON.stringify(body);
-		}
+    if (body && method !== 'GET') {
+      options.body = JSON.stringify(body);
+    }
 
-		const response = await fetch(`${GRAPHY_API_BASE}${path}`, options);
+    const response = await fetch(`${GRAPHY_API_BASE}${path}`, options);
 
-		if (!response.ok) {
-			let errorMessage = `HTTP ${response.status}: ${response.statusText}`;
-			try {
-				const errorBody = (await response.json()) as {
-					message?: string;
-					error?: string;
-				};
-				if (errorBody.message) {
-					errorMessage = errorBody.message;
-				}
-				if (errorBody.error) {
-					errorMessage = errorBody.error;
-				}
-			} catch {
-				// If we can't parse the error, use the basic message
-			}
-			throw new Error(errorMessage);
-		}
+    if (!response.ok) {
+      let errorMessage = `HTTP ${response.status}: ${response.statusText}`;
+      try {
+        const errorBody = (await response.json()) as {
+          message?: string;
+          error?: string;
+        };
+        if (errorBody.message) {
+          errorMessage = errorBody.message;
+        }
+        if (errorBody.error) {
+          errorMessage = errorBody.error;
+        }
+      } catch {
+        // If we can't parse the error, use the basic message
+      }
+      throw new Error(errorMessage);
+    }
 
-		const contentType = response.headers.get("content-type");
-		if (contentType?.includes("application/json")) {
-			return response.json();
-		}
-		return response.text();
-	}
+    const contentType = response.headers.get('content-type');
+    if (contentType?.includes('application/json')) {
+      return response.json();
+    }
+    return response.text();
+  }
 
-	async getBoards(limit = 50, offset = 0): Promise<GraphyBoard[]> {
-		const params = new URLSearchParams({
-			limit: limit.toString(),
-			offset: offset.toString(),
-		});
+  async getBoards(limit = 50, offset = 0): Promise<GraphyBoard[]> {
+    const params = new URLSearchParams({
+      limit: limit.toString(),
+      offset: offset.toString(),
+    });
 
-		const response = await this.makeRequest(`/boards?${params}`);
-		if (typeof response === "object" && response && "results" in response) {
-			return response.results as GraphyBoard[];
-		}
-		return Array.isArray(response) ? response : [];
-	}
+    const response = await this.makeRequest(`/boards?${params}`);
+    if (typeof response === 'object' && response && 'results' in response) {
+      return response.results as GraphyBoard[];
+    }
+    return Array.isArray(response) ? response : [];
+  }
 
-	async getBoard(boardId: string): Promise<GraphyBoard> {
-		const response = await this.makeRequest(`/boards/${boardId}`);
-		if (typeof response === "object" && response && "data" in response) {
-			return response.data as GraphyBoard;
-		}
-		return response as GraphyBoard;
-	}
+  async getBoard(boardId: string): Promise<GraphyBoard> {
+    const response = await this.makeRequest(`/boards/${boardId}`);
+    if (typeof response === 'object' && response && 'data' in response) {
+      return response.data as GraphyBoard;
+    }
+    return response as GraphyBoard;
+  }
 
-	async createBoard(
-		title: string,
-		type: string,
-		description?: string,
-		datasetId?: string,
-		config?: Record<string, unknown>,
-	): Promise<GraphyBoard> {
-		const body: Record<string, unknown> = {
-			title,
-			type,
-			description,
-			dataset_id: datasetId,
-			config,
-		};
+  async createBoard(
+    title: string,
+    type: string,
+    description?: string,
+    datasetId?: string,
+    config?: Record<string, unknown>
+  ): Promise<GraphyBoard> {
+    const body: Record<string, unknown> = {
+      title,
+      type,
+      description,
+      dataset_id: datasetId,
+      config,
+    };
 
-		const response = await this.makeRequest("/boards", "POST", body);
-		if (typeof response === "object" && response && "data" in response) {
-			return response.data as GraphyBoard;
-		}
-		return response as GraphyBoard;
-	}
+    const response = await this.makeRequest('/boards', 'POST', body);
+    if (typeof response === 'object' && response && 'data' in response) {
+      return response.data as GraphyBoard;
+    }
+    return response as GraphyBoard;
+  }
 
-	async updateBoard(
-		boardId: string,
-		title?: string,
-		description?: string,
-		config?: Record<string, unknown>,
-	): Promise<GraphyBoard> {
-		const body: Record<string, unknown> = {};
-		if (title !== undefined) body.title = title;
-		if (description !== undefined) body.description = description;
-		if (config !== undefined) body.config = config;
+  async updateBoard(
+    boardId: string,
+    title?: string,
+    description?: string,
+    config?: Record<string, unknown>
+  ): Promise<GraphyBoard> {
+    const body: Record<string, unknown> = {};
+    if (title !== undefined) body.title = title;
+    if (description !== undefined) body.description = description;
+    if (config !== undefined) body.config = config;
 
-		const response = await this.makeRequest(`/boards/${boardId}`, "PUT", body);
-		if (typeof response === "object" && response && "data" in response) {
-			return response.data as GraphyBoard;
-		}
-		return response as GraphyBoard;
-	}
+    const response = await this.makeRequest(`/boards/${boardId}`, 'PUT', body);
+    if (typeof response === 'object' && response && 'data' in response) {
+      return response.data as GraphyBoard;
+    }
+    return response as GraphyBoard;
+  }
 
-	async deleteBoard(boardId: string): Promise<boolean> {
-		await this.makeRequest(`/boards/${boardId}`, "DELETE");
-		return true;
-	}
+  async deleteBoard(boardId: string): Promise<boolean> {
+    await this.makeRequest(`/boards/${boardId}`, 'DELETE');
+    return true;
+  }
 
-	async getDatasets(limit = 50, offset = 0): Promise<GraphyDataset[]> {
-		const params = new URLSearchParams({
-			limit: limit.toString(),
-			offset: offset.toString(),
-		});
+  async getDatasets(limit = 50, offset = 0): Promise<GraphyDataset[]> {
+    const params = new URLSearchParams({
+      limit: limit.toString(),
+      offset: offset.toString(),
+    });
 
-		const response = await this.makeRequest(`/datasets?${params}`);
-		if (typeof response === "object" && response && "results" in response) {
-			return response.results as GraphyDataset[];
-		}
-		return Array.isArray(response) ? response : [];
-	}
+    const response = await this.makeRequest(`/datasets?${params}`);
+    if (typeof response === 'object' && response && 'results' in response) {
+      return response.results as GraphyDataset[];
+    }
+    return Array.isArray(response) ? response : [];
+  }
 
-	async getDataset(datasetId: string): Promise<GraphyDataset> {
-		const response = await this.makeRequest(`/datasets/${datasetId}`);
-		if (typeof response === "object" && response && "data" in response) {
-			return response.data as GraphyDataset;
-		}
-		return response as GraphyDataset;
-	}
+  async getDataset(datasetId: string): Promise<GraphyDataset> {
+    const response = await this.makeRequest(`/datasets/${datasetId}`);
+    if (typeof response === 'object' && response && 'data' in response) {
+      return response.data as GraphyDataset;
+    }
+    return response as GraphyDataset;
+  }
 
-	async createDataset(
-		name: string,
-		data: unknown[][],
-		columns: Array<{ name: string; type: string }>,
-		description?: string,
-	): Promise<GraphyDataset> {
-		const body = {
-			name,
-			description,
-			data,
-			columns,
-		};
+  async createDataset(
+    name: string,
+    data: unknown[][],
+    columns: Array<{ name: string; type: string }>,
+    description?: string
+  ): Promise<GraphyDataset> {
+    const body = {
+      name,
+      description,
+      data,
+      columns,
+    };
 
-		const response = await this.makeRequest("/datasets", "POST", body);
-		if (typeof response === "object" && response && "data" in response) {
-			return response.data as GraphyDataset;
-		}
-		return response as GraphyDataset;
-	}
+    const response = await this.makeRequest('/datasets', 'POST', body);
+    if (typeof response === 'object' && response && 'data' in response) {
+      return response.data as GraphyDataset;
+    }
+    return response as GraphyDataset;
+  }
 
-	async getBoardData(boardId: string, format = "json"): Promise<unknown> {
-		const params = new URLSearchParams({ format });
-		return this.makeRequest(`/boards/${boardId}/data?${params}`);
-	}
+  async getBoardData(boardId: string, format = 'json'): Promise<unknown> {
+    const params = new URLSearchParams({ format });
+    return this.makeRequest(`/boards/${boardId}/data?${params}`);
+  }
 
-	async shareBoard(boardId: string, isPublic = true): Promise<string> {
-		const body = { is_public: isPublic };
-		const response = await this.makeRequest(
-			`/boards/${boardId}/share`,
-			"POST",
-			body,
-		);
-		if (typeof response === "object" && response && "embed_url" in response) {
-			return response.embed_url as string;
-		}
-		if (typeof response === "object" && response && "data" in response) {
-			const data = response.data as { embed_url?: string };
-			return data.embed_url || "";
-		}
-		return "";
-	}
+  async shareBoard(boardId: string, isPublic = true): Promise<string> {
+    const body = { is_public: isPublic };
+    const response = await this.makeRequest(`/boards/${boardId}/share`, 'POST', body);
+    if (typeof response === 'object' && response && 'embed_url' in response) {
+      return response.embed_url as string;
+    }
+    if (typeof response === 'object' && response && 'data' in response) {
+      const data = response.data as { embed_url?: string };
+      return data.embed_url || '';
+    }
+    return '';
+  }
 }
 
 const handleGraphyError = (error: unknown): string => {
-	if (error instanceof Error) {
-		const message = error.message.toLowerCase();
-
-		if (message.includes("unauthorized") || message.includes("401")) {
-			return "Error: Unauthorized. Please check your Graphy API token and permissions.";
-		}
-		if (message.includes("not found") || message.includes("404")) {
-			return "Error: API endpoint not found. The Graphy REST API may not be available yet or the endpoint path may have changed. Please check the API documentation at https://visualize.graphy.app/rest-api for the correct endpoints.";
-		}
-		if (message.includes("forbidden") || message.includes("403")) {
-			return "Error: Access forbidden. Your API token may not have permission to access this resource.";
-		}
-		if (message.includes("rate") || message.includes("429")) {
-			return "Error: Rate limited. Please wait before making more requests.";
-		}
-		if (message.includes("validation") || message.includes("400")) {
-			return `Error: Invalid request. ${error.message}`;
-		}
-		if (message.includes("conflict") || message.includes("409")) {
-			return "Error: Conflict. The resource you're trying to create already exists.";
-		}
-		if (message.includes("server error") || message.includes("500")) {
-			return "Error: Internal server error. Please try again later.";
-		}
-		if (message.includes("service unavailable") || message.includes("503")) {
-			return "Error: Service unavailable. Please try again later.";
-		}
-
-		return `Error: ${error.message}`;
-	}
-
-	return `Error: ${String(error)}`;
+  if (error instanceof Error) {
+    return error.message;
+  }
+  return String(error);
 };
 
 export const GraphyConnectorConfig = mcpConnectorConfig({
-	name: "Graphy",
-	key: "graphy",
-	version: "1.0.0",
-	logo: "https://stackone-logos.com/api/graphy/filled/svg",
-	credentials: z.object({
-		apiToken: z
-			.string()
-			.describe(
-				"Graphy API token from your account settings :: token_1234567890abcdef :: https://visualize.graphy.app/account/api",
-			),
-	}),
-	setup: z.object({}),
-	examplePrompt:
-		"Create a bar chart for sales data, list all my existing boards, and share a board publicly to get an embed URL. Show me all my datasets and create a line chart from the revenue dataset to visualize monthly trends. Create a pie chart showing user distribution by country from my analytics dataset, then share it publicly.",
-	tools: (tool) => ({
-		LIST_BOARDS: tool({
-			name: "graphy_list_boards",
-			description: "List all boards in your Graphy account",
-			schema: z.object({
-				limit: z
-					.number()
-					.min(1)
-					.max(100)
-					.optional()
-					.default(50)
-					.describe("Number of boards to return (max 100)"),
-				offset: z
-					.number()
-					.min(0)
-					.optional()
-					.default(0)
-					.describe("Number of boards to skip for pagination"),
-			}),
-			handler: async (args, context) => {
-				try {
-					const { apiToken } = await context.getCredentials();
-					const client = new GraphyClient(apiToken);
-					const boards = await client.getBoards(args.limit, args.offset);
-					return JSON.stringify(boards, null, 2);
-				} catch (error) {
-					return handleGraphyError(error);
-				}
-			},
-		}),
-		GET_BOARD: tool({
-			name: "graphy_get_board",
-			description: "Get details of a specific board by ID",
-			schema: z.object({
-				boardId: z.string().describe("The ID of the board to retrieve"),
-			}),
-			handler: async (args, context) => {
-				try {
-					const { apiToken } = await context.getCredentials();
-					const client = new GraphyClient(apiToken);
-					const board = await client.getBoard(args.boardId);
-					return JSON.stringify(board, null, 2);
-				} catch (error) {
-					return handleGraphyError(error);
-				}
-			},
-		}),
-		CREATE_BOARD: tool({
-			name: "graphy_create_board",
-			description: "Create a new board in Graphy",
-			schema: z.object({
-				title: z.string().describe("Board title"),
-				type: z
-					.string()
-					.describe("Board type (bar, line, pie, scatter, area, etc.)"),
-				description: z.string().optional().describe("Board description"),
-				datasetId: z
-					.string()
-					.optional()
-					.describe("ID of dataset to use for the board"),
-				config: z
-					.record(z.unknown())
-					.optional()
-					.describe("Board configuration options"),
-			}),
-			handler: async (args, context) => {
-				try {
-					const { apiToken } = await context.getCredentials();
-					const client = new GraphyClient(apiToken);
-					const board = await client.createBoard(
-						args.title,
-						args.type,
-						args.description,
-						args.datasetId,
-						args.config,
-					);
-					return JSON.stringify(board, null, 2);
-				} catch (error) {
-					return handleGraphyError(error);
-				}
-			},
-		}),
-		UPDATE_BOARD: tool({
-			name: "graphy_update_board",
-			description: "Update an existing board",
-			schema: z.object({
-				boardId: z.string().describe("The ID of the board to update"),
-				title: z.string().optional().describe("New board title"),
-				description: z.string().optional().describe("New board description"),
-				config: z
-					.record(z.unknown())
-					.optional()
-					.describe("Updated board configuration options"),
-			}),
-			handler: async (args, context) => {
-				try {
-					const { apiToken } = await context.getCredentials();
-					const client = new GraphyClient(apiToken);
-					const board = await client.updateBoard(
-						args.boardId,
-						args.title,
-						args.description,
-						args.config,
-					);
-					return JSON.stringify(board, null, 2);
-				} catch (error) {
-					return handleGraphyError(error);
-				}
-			},
-		}),
-		DELETE_BOARD: tool({
-			name: "graphy_delete_board",
-			description: "Delete a board by ID",
-			schema: z.object({
-				boardId: z.string().describe("The ID of the board to delete"),
-			}),
-			handler: async (args, context) => {
-				try {
-					const { apiToken } = await context.getCredentials();
-					const client = new GraphyClient(apiToken);
-					await client.deleteBoard(args.boardId);
-					return `Board ${args.boardId} deleted successfully`;
-				} catch (error) {
-					return handleGraphyError(error);
-				}
-			},
-		}),
-		LIST_DATASETS: tool({
-			name: "graphy_list_datasets",
-			description: "List all datasets in your Graphy account",
-			schema: z.object({
-				limit: z
-					.number()
-					.min(1)
-					.max(100)
-					.optional()
-					.default(50)
-					.describe("Number of datasets to return (max 100)"),
-				offset: z
-					.number()
-					.min(0)
-					.optional()
-					.default(0)
-					.describe("Number of datasets to skip for pagination"),
-			}),
-			handler: async (args, context) => {
-				try {
-					const { apiToken } = await context.getCredentials();
-					const client = new GraphyClient(apiToken);
-					const datasets = await client.getDatasets(args.limit, args.offset);
-					return JSON.stringify(datasets, null, 2);
-				} catch (error) {
-					return handleGraphyError(error);
-				}
-			},
-		}),
-		GET_DATASET: tool({
-			name: "graphy_get_dataset",
-			description: "Get details of a specific dataset by ID",
-			schema: z.object({
-				datasetId: z.string().describe("The ID of the dataset to retrieve"),
-			}),
-			handler: async (args, context) => {
-				try {
-					const { apiToken } = await context.getCredentials();
-					const client = new GraphyClient(apiToken);
-					const dataset = await client.getDataset(args.datasetId);
-					return JSON.stringify(dataset, null, 2);
-				} catch (error) {
-					return handleGraphyError(error);
-				}
-			},
-		}),
-		CREATE_DATASET: tool({
-			name: "graphy_create_dataset",
-			description: "Create a new dataset with data",
-			schema: z.object({
-				name: z.string().describe("Dataset name"),
-				data: z.array(z.array(z.unknown())).describe("Array of data rows"),
-				columns: z
-					.array(
-						z.object({
-							name: z.string().describe("Column name"),
-							type: z
-								.string()
-								.describe("Column data type (string, number, date, boolean)"),
-						}),
-					)
-					.describe("Array of column definitions"),
-				description: z.string().optional().describe("Dataset description"),
-			}),
-			handler: async (args, context) => {
-				try {
-					const { apiToken } = await context.getCredentials();
-					const client = new GraphyClient(apiToken);
-					const dataset = await client.createDataset(
-						args.name,
-						args.data,
-						args.columns,
-						args.description,
-					);
-					return JSON.stringify(dataset, null, 2);
-				} catch (error) {
-					return handleGraphyError(error);
-				}
-			},
-		}),
-		GET_BOARD_DATA: tool({
-			name: "graphy_get_board_data",
-			description: "Get the underlying data for a board",
-			schema: z.object({
-				boardId: z.string().describe("The ID of the board to get data for"),
-				format: z
-					.enum(["json", "csv", "xlsx"])
-					.optional()
-					.default("json")
-					.describe("Data format to return"),
-			}),
-			handler: async (args, context) => {
-				try {
-					const { apiToken } = await context.getCredentials();
-					const client = new GraphyClient(apiToken);
-					const data = await client.getBoardData(args.boardId, args.format);
-					if (args.format === "json") {
-						return JSON.stringify(data, null, 2);
-					}
-					return String(data);
-				} catch (error) {
-					return handleGraphyError(error);
-				}
-			},
-		}),
-		SHARE_BOARD: tool({
-			name: "graphy_share_board",
-			description: "Share a board publicly and get an embed URL",
-			schema: z.object({
-				boardId: z.string().describe("The ID of the board to share"),
-				isPublic: z
-					.boolean()
-					.optional()
-					.default(true)
-					.describe("Whether to make the board publicly accessible"),
-			}),
-			handler: async (args, context) => {
-				try {
-					const { apiToken } = await context.getCredentials();
-					const client = new GraphyClient(apiToken);
-					const embedUrl = await client.shareBoard(args.boardId, args.isPublic);
-					return `Board shared successfully. Embed URL: ${embedUrl}`;
-				} catch (error) {
-					return handleGraphyError(error);
-				}
-			},
-		}),
-	}),
+  name: 'Graphy',
+  key: 'graphy',
+  version: '1.0.0',
+  logo: 'https://stackone-logos.com/api/graphy/filled/svg',
+  credentials: z.object({
+    apiToken: z
+      .string()
+      .describe(
+        'Graphy API token from your account settings :: token_1234567890abcdef :: https://visualize.graphy.app/account/api'
+      ),
+  }),
+  setup: z.object({}),
+  examplePrompt:
+    'Create a bar chart for sales data, list all my existing boards, and share a board publicly to get an embed URL. Show me all my datasets and create a line chart from the revenue dataset to visualize monthly trends. Create a pie chart showing user distribution by country from my analytics dataset, then share it publicly.',
+  tools: (tool) => ({
+    LIST_BOARDS: tool({
+      name: 'graphy_list_boards',
+      description: 'List all boards in your Graphy account',
+      schema: z.object({
+        limit: z
+          .number()
+          .min(1)
+          .max(100)
+          .optional()
+          .default(50)
+          .describe('Number of boards to return (max 100)'),
+        offset: z
+          .number()
+          .min(0)
+          .optional()
+          .default(0)
+          .describe('Number of boards to skip for pagination'),
+      }),
+      handler: async (args, context) => {
+        try {
+          const { apiToken } = await context.getCredentials();
+          const client = new GraphyClient(apiToken);
+          const boards = await client.getBoards(args.limit, args.offset);
+          return JSON.stringify(boards, null, 2);
+        } catch (error) {
+          return handleGraphyError(error);
+        }
+      },
+    }),
+    GET_BOARD: tool({
+      name: 'graphy_get_board',
+      description: 'Get details of a specific board by ID',
+      schema: z.object({
+        boardId: z.string().describe('The ID of the board to retrieve'),
+      }),
+      handler: async (args, context) => {
+        try {
+          const { apiToken } = await context.getCredentials();
+          const client = new GraphyClient(apiToken);
+          const board = await client.getBoard(args.boardId);
+          return JSON.stringify(board, null, 2);
+        } catch (error) {
+          return handleGraphyError(error);
+        }
+      },
+    }),
+    CREATE_BOARD: tool({
+      name: 'graphy_create_board',
+      description: 'Create a new board in Graphy',
+      schema: z.object({
+        title: z.string().describe('Board title'),
+        type: z.string().describe('Board type (bar, line, pie, scatter, area, etc.)'),
+        description: z.string().optional().describe('Board description'),
+        datasetId: z.string().optional().describe('ID of dataset to use for the board'),
+        config: z.record(z.unknown()).optional().describe('Board configuration options'),
+      }),
+      handler: async (args, context) => {
+        try {
+          const { apiToken } = await context.getCredentials();
+          const client = new GraphyClient(apiToken);
+          const board = await client.createBoard(
+            args.title,
+            args.type,
+            args.description,
+            args.datasetId,
+            args.config
+          );
+          return JSON.stringify(board, null, 2);
+        } catch (error) {
+          return handleGraphyError(error);
+        }
+      },
+    }),
+    UPDATE_BOARD: tool({
+      name: 'graphy_update_board',
+      description: 'Update an existing board',
+      schema: z.object({
+        boardId: z.string().describe('The ID of the board to update'),
+        title: z.string().optional().describe('New board title'),
+        description: z.string().optional().describe('New board description'),
+        config: z
+          .record(z.unknown())
+          .optional()
+          .describe('Updated board configuration options'),
+      }),
+      handler: async (args, context) => {
+        try {
+          const { apiToken } = await context.getCredentials();
+          const client = new GraphyClient(apiToken);
+          const board = await client.updateBoard(
+            args.boardId,
+            args.title,
+            args.description,
+            args.config
+          );
+          return JSON.stringify(board, null, 2);
+        } catch (error) {
+          return handleGraphyError(error);
+        }
+      },
+    }),
+    DELETE_BOARD: tool({
+      name: 'graphy_delete_board',
+      description: 'Delete a board by ID',
+      schema: z.object({
+        boardId: z.string().describe('The ID of the board to delete'),
+      }),
+      handler: async (args, context) => {
+        try {
+          const { apiToken } = await context.getCredentials();
+          const client = new GraphyClient(apiToken);
+          await client.deleteBoard(args.boardId);
+          return `Board ${args.boardId} deleted successfully`;
+        } catch (error) {
+          return handleGraphyError(error);
+        }
+      },
+    }),
+    LIST_DATASETS: tool({
+      name: 'graphy_list_datasets',
+      description: 'List all datasets in your Graphy account',
+      schema: z.object({
+        limit: z
+          .number()
+          .min(1)
+          .max(100)
+          .optional()
+          .default(50)
+          .describe('Number of datasets to return (max 100)'),
+        offset: z
+          .number()
+          .min(0)
+          .optional()
+          .default(0)
+          .describe('Number of datasets to skip for pagination'),
+      }),
+      handler: async (args, context) => {
+        try {
+          const { apiToken } = await context.getCredentials();
+          const client = new GraphyClient(apiToken);
+          const datasets = await client.getDatasets(args.limit, args.offset);
+          return JSON.stringify(datasets, null, 2);
+        } catch (error) {
+          return handleGraphyError(error);
+        }
+      },
+    }),
+    GET_DATASET: tool({
+      name: 'graphy_get_dataset',
+      description: 'Get details of a specific dataset by ID',
+      schema: z.object({
+        datasetId: z.string().describe('The ID of the dataset to retrieve'),
+      }),
+      handler: async (args, context) => {
+        try {
+          const { apiToken } = await context.getCredentials();
+          const client = new GraphyClient(apiToken);
+          const dataset = await client.getDataset(args.datasetId);
+          return JSON.stringify(dataset, null, 2);
+        } catch (error) {
+          return handleGraphyError(error);
+        }
+      },
+    }),
+    CREATE_DATASET: tool({
+      name: 'graphy_create_dataset',
+      description: 'Create a new dataset with data',
+      schema: z.object({
+        name: z.string().describe('Dataset name'),
+        data: z.array(z.array(z.unknown())).describe('Array of data rows'),
+        columns: z
+          .array(
+            z.object({
+              name: z.string().describe('Column name'),
+              type: z
+                .string()
+                .describe('Column data type (string, number, date, boolean)'),
+            })
+          )
+          .describe('Array of column definitions'),
+        description: z.string().optional().describe('Dataset description'),
+      }),
+      handler: async (args, context) => {
+        try {
+          const { apiToken } = await context.getCredentials();
+          const client = new GraphyClient(apiToken);
+          const dataset = await client.createDataset(
+            args.name,
+            args.data,
+            args.columns,
+            args.description
+          );
+          return JSON.stringify(dataset, null, 2);
+        } catch (error) {
+          return handleGraphyError(error);
+        }
+      },
+    }),
+    GET_BOARD_DATA: tool({
+      name: 'graphy_get_board_data',
+      description: 'Get the underlying data for a board',
+      schema: z.object({
+        boardId: z.string().describe('The ID of the board to get data for'),
+        format: z
+          .enum(['json', 'csv', 'xlsx'])
+          .optional()
+          .default('json')
+          .describe('Data format to return'),
+      }),
+      handler: async (args, context) => {
+        try {
+          const { apiToken } = await context.getCredentials();
+          const client = new GraphyClient(apiToken);
+          const data = await client.getBoardData(args.boardId, args.format);
+          if (args.format === 'json') {
+            return JSON.stringify(data, null, 2);
+          }
+          return String(data);
+        } catch (error) {
+          return handleGraphyError(error);
+        }
+      },
+    }),
+    SHARE_BOARD: tool({
+      name: 'graphy_share_board',
+      description: 'Share a board publicly and get an embed URL',
+      schema: z.object({
+        boardId: z.string().describe('The ID of the board to share'),
+        isPublic: z
+          .boolean()
+          .optional()
+          .default(true)
+          .describe('Whether to make the board publicly accessible'),
+      }),
+      handler: async (args, context) => {
+        try {
+          const { apiToken } = await context.getCredentials();
+          const client = new GraphyClient(apiToken);
+          const embedUrl = await client.shareBoard(args.boardId, args.isPublic);
+          return `Board shared successfully. Embed URL: ${embedUrl}`;
+        } catch (error) {
+          return handleGraphyError(error);
+        }
+      },
+    }),
+  }),
 });

--- a/packages/mcp-connectors/src/index.ts
+++ b/packages/mcp-connectors/src/index.ts
@@ -15,6 +15,7 @@ import { FalConnectorConfig } from './connectors/fal';
 import { FirefliesConnectorConfig } from './connectors/fireflies';
 import { GitHubConnectorConfig } from './connectors/github';
 import { GoogleDriveConnectorConfig } from './connectors/google-drive';
+import { GraphyConnectorConfig } from './connectors/graphy';
 import { HiBobConnectorConfig } from './connectors/hibob';
 import { HubSpotConnectorConfig } from './connectors/hubspot';
 import { IncidentConnectorConfig } from './connectors/incident';
@@ -64,6 +65,7 @@ export const Connectors: readonly MCPConnectorConfig[] = [
   FalConnectorConfig,
   GitHubConnectorConfig,
   GoogleDriveConnectorConfig,
+  GraphyConnectorConfig,
   HiBobConnectorConfig,
   HubSpotConnectorConfig,
   IncidentConnectorConfig,
@@ -113,6 +115,7 @@ export {
   FalConnectorConfig,
   GitHubConnectorConfig,
   GoogleDriveConnectorConfig,
+  GraphyConnectorConfig,
   HiBobConnectorConfig,
   HubSpotConnectorConfig,
   IncidentConnectorConfig,


### PR DESCRIPTION
- Introduced a new Graphy connector that allows users to manage boards and datasets.
- Implemented tools for listing, creating, updating, and deleting boards and datasets.
- Added comprehensive tests for all functionalities using MSW and Vitest.
- Registered the Graphy connector in the main index for easy access.

This enhancement expands the capabilities of the MCP connectors, enabling integration with the Graphy API for data visualization and management.
    
<!-- This is an auto-generated description by cubic. -->
---

## Summary by cubic
Adds a new Graphy connector to manage boards and datasets via the Graphy REST API. Provides CRUD tools, data export, and sharing, with full test coverage and registration for immediate use.

- **New Features**
  - Boards: list/get/create/update/delete and share (returns embed URL); pagination supported.
  - Datasets: list/get/create with data and column definitions.
  - Data: fetch board data as JSON/CSV/XLSX.
  - Error handling: clear messages for 401/403/404/429 and common failures.
  - Setup: requires apiToken credential; connector registered in the index.

<!-- End of auto-generated description by cubic. -->

