### PR TITLE
fix: shebang  bun -> node

### DIFF
--- a/apps/mcp-test/src/index.ts
+++ b/apps/mcp-test/src/index.ts
@@ -1,4 +1,4 @@
-#!/usr/bin/env bun
+#!/usr/bin/env node
 
 import fs from 'node:fs';
 import os from 'node:os';

--- a/apps/mcp-test/src/internal-server.ts
+++ b/apps/mcp-test/src/internal-server.ts
@@ -1,3 +1,5 @@
+#!/usr/bin/env node
+
 import { faker } from '@faker-js/faker';
 import { McpServer } from '@modelcontextprotocol/sdk/server/mcp.js';
 import { StdioServerTransport } from '@modelcontextprotocol/sdk/server/stdio.js';

--- a/apps/mcp-test/src/internal-server.ts
+++ b/apps/mcp-test/src/internal-server.ts
@@ -1,5 +1,3 @@
-#!/usr/bin/env bun
-
 import { faker } from '@faker-js/faker';
 import { McpServer } from '@modelcontextprotocol/sdk/server/mcp.js';
 import { StdioServerTransport } from '@modelcontextprotocol/sdk/server/stdio.js';


### PR DESCRIPTION

    
<!-- This is an auto-generated description by cubic. -->

## Summary by cubic
Switched shebangs from bun to node so the CLI runs under Node by default. This removes the Bun dependency and fixes execution errors on systems without Bun.

<!-- End of auto-generated description by cubic. -->

