### PR TITLE
fix: dirname -> import.meta.dirname

### DIFF
--- a/apps/mcp-test/src/index.ts
+++ b/apps/mcp-test/src/index.ts
@@ -38,7 +38,7 @@ async function main() {
 
   try {
     // Get the path to the test-data MCP server
-    const testDataServerPath = path.join(__dirname, 'internal-server.ts');
+    const testDataServerPath = path.join(import.meta.dirname, 'internal-server.ts');
 
     const mcpConfig: Record<string, McpServerConfig> = {
       'internal-helper': {


### PR DESCRIPTION

    
<!-- This is an auto-generated description by cubic. -->

## Summary by cubic
Switched __dirname to import.meta.dirname in the MCP test app to resolve internal-server.ts correctly under ESM. This prevents runtime errors when starting the internal test server.

<!-- End of auto-generated description by cubic. -->

