### PR TITLE
fix: move ts to deps

### DIFF
--- a/apps/mcp-test/package.json
+++ b/apps/mcp-test/package.json
@@ -28,10 +28,8 @@
   "author": "",
   "license": "MIT",
   "devDependencies": {
+    "typescript": "^5",
     "@types/bun": "latest"
-  },
-  "peerDependencies": {
-    "typescript": "^5"
   },
   "dependencies": {
     "@anthropic-ai/claude-code": "^1.0.109",

--- a/bun.lock
+++ b/bun.lock
@@ -24,7 +24,7 @@
     },
     "apps/mcp-test": {
       "name": "@stackone/mcp-test",
-      "version": "0.0.2",
+      "version": "0.0.3",
       "bin": {
         "mcp-test": "./dist/index.js",
       },
@@ -37,8 +37,6 @@
       },
       "devDependencies": {
         "@types/bun": "latest",
-      },
-      "peerDependencies": {
         "typescript": "^5",
       },
     },
@@ -69,7 +67,7 @@
     },
     "packages/mcp-connectors": {
       "name": "@stackone/mcp-connectors",
-      "version": "0.0.15",
+      "version": "0.0.16",
       "dependencies": {
         "@1password/connect": "^1.4.2",
         "@linear/sdk": "^55.0.0",


### PR DESCRIPTION

    
<!-- This is an auto-generated description by cubic. -->

## Summary by cubic
Moved TypeScript from peerDependencies to devDependencies in apps/mcp-test so it’s installed and builds run reliably. Updated bun.lock and bumped package versions to reflect the change.

<!-- End of auto-generated description by cubic. -->

