### PR TITLE
feat: use which command to detect claude path automatically

### DIFF
--- a/apps/mcp-test/src/index.ts
+++ b/apps/mcp-test/src/index.ts
@@ -7,6 +7,7 @@ import { type McpServerConfig, query } from '@anthropic-ai/claude-code';
 import { parseCli } from './cli';
 import { discoverTools } from './discover-tools';
 import { createTestingPrompt } from './prompt';
+import { which } from './utils';
 
 async function main() {
   const options = parseCli();
@@ -66,7 +67,7 @@ async function main() {
         mcpServers: mcpConfig,
         strictMcpConfig: true,
         model: 'claude-sonnet-4-20250514',
-        pathToClaudeCodeExecutable: process.env.CLAUDE_CODE_PATH || 'claude',
+        pathToClaudeCodeExecutable: process.env.CLAUDE_CODE_PATH ?? which('claude'),
         disallowedTools: [
           'Bash',
           'BashOutput',

--- a/apps/mcp-test/src/utils.ts
+++ b/apps/mcp-test/src/utils.ts
@@ -1,0 +1,16 @@
+import childProcess from 'node:child_process';
+
+/**
+ * Synchronously finds the full path of a command in the system's PATH.
+ * not for windows
+ */
+export function which(command: string): string | undefined {
+  try {
+    const result = childProcess
+      .execSync(`which ${command}`, { encoding: 'utf-8' })
+      .trim();
+    return result ?? undefined;
+  } catch {
+    return undefined;
+  }
+}


### PR DESCRIPTION

    
<!-- This is an auto-generated description by cubic. -->

## Summary by cubic
Automatically detect the Claude Code executable path using which on Unix-like systems, preferring the CLAUDE_CODE_PATH env var when set. This removes the hardcoded 'claude' default and reduces launch errors when the binary isn’t on PATH.

- **New Features**
  - Resolution order: CLAUDE_CODE_PATH -> which('claude'); Windows not supported.
  - Added utils.which() using child_process.execSync.

<!-- End of auto-generated description by cubic. -->

