### PR TITLE
fix: top-level-awai and remove import.meta.main

### DIFF
--- a/apps/mcp-test/src/index.ts
+++ b/apps/mcp-test/src/index.ts
@@ -159,9 +159,4 @@ async function main() {
   }
 }
 
-if (import.meta.main) {
-  main().catch((error) => {
-    console.error('Unhandled error:', error);
-    process.exit(1);
-  });
-}
+await main();

--- a/apps/mcp-test/src/internal-server.ts
+++ b/apps/mcp-test/src/internal-server.ts
@@ -409,7 +409,4 @@ async function main() {
   console.error('Test Data Generator MCP Server running on stdio');
 }
 
-main().catch((error) => {
-  console.error('Server error:', error);
-  process.exit(1);
-});
+await main();


### PR DESCRIPTION

    
<!-- This is an auto-generated description by cubic. -->

## Summary by cubic
Switch mcp-test entrypoints to top-level await by calling await main(), removing import.meta.main checks and manual process.exit error handling. This simplifies startup and fixes top-level-await runtime issues.

<!-- End of auto-generated description by cubic. -->

