### PR TITLE
fix(hubspot): update connector for Private App authentication

### DIFF
--- a/packages/mcp-connectors/src/connectors/hubspot.ts
+++ b/packages/mcp-connectors/src/connectors/hubspot.ts
@@ -36,6 +36,11 @@ class HubSpotClient {
 
     if (!response.ok) {
       const error = await response.text();
+      if (response.status === 401) {
+        throw new Error(
+          `HubSpot API error: ${response.status} - Authentication failed. Please ensure you're using a Private App access token, not a Personal Access Key or deprecated API key. ${error}`
+        );
+      }
       throw new Error(`HubSpot API error: ${response.status} - ${error}`);
     }
 
@@ -66,6 +71,11 @@ class HubSpotClient {
 
     if (!response.ok) {
       const error = await response.text();
+      if (response.status === 401) {
+        throw new Error(
+          `HubSpot API error: ${response.status} - Authentication failed. Please ensure you're using a Private App access token, not a Personal Access Key or deprecated API key. ${error}`
+        );
+      }
       throw new Error(`HubSpot API error: ${response.status} - ${error}`);
     }
 
@@ -84,6 +94,11 @@ class HubSpotClient {
 
     if (!response.ok) {
       const error = await response.text();
+      if (response.status === 401) {
+        throw new Error(
+          `HubSpot API error: ${response.status} - Authentication failed. Please ensure you're using a Private App access token, not a Personal Access Key or deprecated API key. ${error}`
+        );
+      }
       throw new Error(`HubSpot API error: ${response.status} - ${error}`);
     }
 
@@ -102,6 +117,11 @@ class HubSpotClient {
 
     if (!response.ok) {
       const error = await response.text();
+      if (response.status === 401) {
+        throw new Error(
+          `HubSpot API error: ${response.status} - Authentication failed. Please ensure you're using a Private App access token, not a Personal Access Key or deprecated API key. ${error}`
+        );
+      }
       throw new Error(`HubSpot API error: ${response.status} - ${error}`);
     }
 
@@ -116,7 +136,9 @@ export const HubSpotConnectorConfig = mcpConnectorConfig({
   credentials: z.object({
     apiKey: z
       .string()
-      .describe('Your HubSpot API key from Settings > Integrations > API Key'),
+      .describe(
+        'Your HubSpot Private App access token from Settings > Integrations > Private Apps. Note: Personal Access Keys are only for local development tools and will not work with this connector.'
+      ),
   }),
   logo: 'https://stackone-logos.com/api/hubspot/filled/svg',
   setup: z.object({}),

--- a/packages/mcp-connectors/src/connectors/hubspot.ts
+++ b/packages/mcp-connectors/src/connectors/hubspot.ts
@@ -37,12 +37,11 @@ class HubSpotClient {
     if (!response.ok) {
       const error = await response.text();
       if (response.status === 401) {
-        throw new Error(
-          error ||
-            "Authentication failed. Please ensure you're using a Private App access token, not a Personal Access Key or deprecated API key."
-        );
+        const authMessage = error ||
+            "Authentication failed. Please ensure you're using a Private App access token, not a Personal Access Key or deprecated API key.";
+        throw new Error(`${authMessage} (${response.status})`);
       }
-      throw new Error(error || `HubSpot API error: ${response.status}`);
+      throw new Error(error ? `${error} (${response.status})` : `HubSpot API error: ${response.status}`);
     }
 
     return response.json();
@@ -73,12 +72,11 @@ class HubSpotClient {
     if (!response.ok) {
       const error = await response.text();
       if (response.status === 401) {
-        throw new Error(
-          error ||
-            "Authentication failed. Please ensure you're using a Private App access token, not a Personal Access Key or deprecated API key."
-        );
+        const authMessage = error ||
+            "Authentication failed. Please ensure you're using a Private App access token, not a Personal Access Key or deprecated API key.";
+        throw new Error(`${authMessage} (${response.status})`);
       }
-      throw new Error(error || `HubSpot API error: ${response.status}`);
+      throw new Error(error ? `${error} (${response.status})` : `HubSpot API error: ${response.status}`);
     }
 
     return response.json();
@@ -97,12 +95,11 @@ class HubSpotClient {
     if (!response.ok) {
       const error = await response.text();
       if (response.status === 401) {
-        throw new Error(
-          error ||
-            "Authentication failed. Please ensure you're using a Private App access token, not a Personal Access Key or deprecated API key."
-        );
+        const authMessage = error ||
+            "Authentication failed. Please ensure you're using a Private App access token, not a Personal Access Key or deprecated API key.";
+        throw new Error(`${authMessage} (${response.status})`);
       }
-      throw new Error(error || `HubSpot API error: ${response.status}`);
+      throw new Error(error ? `${error} (${response.status})` : `HubSpot API error: ${response.status}`);
     }
 
     return response.json();
@@ -121,12 +118,11 @@ class HubSpotClient {
     if (!response.ok) {
       const error = await response.text();
       if (response.status === 401) {
-        throw new Error(
-          error ||
-            "Authentication failed. Please ensure you're using a Private App access token, not a Personal Access Key or deprecated API key."
-        );
+        const authMessage = error ||
+            "Authentication failed. Please ensure you're using a Private App access token, not a Personal Access Key or deprecated API key.";
+        throw new Error(`${authMessage} (${response.status})`);
       }
-      throw new Error(error || `HubSpot API error: ${response.status}`);
+      throw new Error(error ? `${error} (${response.status})` : `HubSpot API error: ${response.status}`);
     }
 
     return response.json();

--- a/packages/mcp-connectors/src/connectors/hubspot.ts
+++ b/packages/mcp-connectors/src/connectors/hubspot.ts
@@ -38,10 +38,11 @@ class HubSpotClient {
       const error = await response.text();
       if (response.status === 401) {
         throw new Error(
-          `HubSpot API error: ${response.status} - Authentication failed. Please ensure you're using a Private App access token, not a Personal Access Key or deprecated API key. ${error}`
+          error ||
+            "Authentication failed. Please ensure you're using a Private App access token, not a Personal Access Key or deprecated API key."
         );
       }
-      throw new Error(`HubSpot API error: ${response.status} - ${error}`);
+      throw new Error(error || `HubSpot API error: ${response.status}`);
     }
 
     return response.json();
@@ -73,10 +74,11 @@ class HubSpotClient {
       const error = await response.text();
       if (response.status === 401) {
         throw new Error(
-          `HubSpot API error: ${response.status} - Authentication failed. Please ensure you're using a Private App access token, not a Personal Access Key or deprecated API key. ${error}`
+          error ||
+            "Authentication failed. Please ensure you're using a Private App access token, not a Personal Access Key or deprecated API key."
         );
       }
-      throw new Error(`HubSpot API error: ${response.status} - ${error}`);
+      throw new Error(error || `HubSpot API error: ${response.status}`);
     }
 
     return response.json();
@@ -96,10 +98,11 @@ class HubSpotClient {
       const error = await response.text();
       if (response.status === 401) {
         throw new Error(
-          `HubSpot API error: ${response.status} - Authentication failed. Please ensure you're using a Private App access token, not a Personal Access Key or deprecated API key. ${error}`
+          error ||
+            "Authentication failed. Please ensure you're using a Private App access token, not a Personal Access Key or deprecated API key."
         );
       }
-      throw new Error(`HubSpot API error: ${response.status} - ${error}`);
+      throw new Error(error || `HubSpot API error: ${response.status}`);
     }
 
     return response.json();
@@ -119,10 +122,11 @@ class HubSpotClient {
       const error = await response.text();
       if (response.status === 401) {
         throw new Error(
-          `HubSpot API error: ${response.status} - Authentication failed. Please ensure you're using a Private App access token, not a Personal Access Key or deprecated API key. ${error}`
+          error ||
+            "Authentication failed. Please ensure you're using a Private App access token, not a Personal Access Key or deprecated API key."
         );
       }
-      throw new Error(`HubSpot API error: ${response.status} - ${error}`);
+      throw new Error(error || `HubSpot API error: ${response.status}`);
     }
 
     return response.json();

--- a/packages/mcp-connectors/src/connectors/hubspot.ts
+++ b/packages/mcp-connectors/src/connectors/hubspot.ts
@@ -37,11 +37,14 @@ class HubSpotClient {
     if (!response.ok) {
       const error = await response.text();
       if (response.status === 401) {
-        const authMessage = error ||
-            "Authentication failed. Please ensure you're using a Private App access token, not a Personal Access Key or deprecated API key.";
+        const authMessage =
+          error ||
+          "Authentication failed. Please ensure you're using a Private App access token, not a Personal Access Key or deprecated API key.";
         throw new Error(`${authMessage} (${response.status})`);
       }
-      throw new Error(error ? `${error} (${response.status})` : `HubSpot API error: ${response.status}`);
+      throw new Error(
+        error ? `${error} (${response.status})` : `HubSpot API error: ${response.status}`
+      );
     }
 
     return response.json();
@@ -72,11 +75,14 @@ class HubSpotClient {
     if (!response.ok) {
       const error = await response.text();
       if (response.status === 401) {
-        const authMessage = error ||
-            "Authentication failed. Please ensure you're using a Private App access token, not a Personal Access Key or deprecated API key.";
+        const authMessage =
+          error ||
+          "Authentication failed. Please ensure you're using a Private App access token, not a Personal Access Key or deprecated API key.";
         throw new Error(`${authMessage} (${response.status})`);
       }
-      throw new Error(error ? `${error} (${response.status})` : `HubSpot API error: ${response.status}`);
+      throw new Error(
+        error ? `${error} (${response.status})` : `HubSpot API error: ${response.status}`
+      );
     }
 
     return response.json();
@@ -95,11 +101,14 @@ class HubSpotClient {
     if (!response.ok) {
       const error = await response.text();
       if (response.status === 401) {
-        const authMessage = error ||
-            "Authentication failed. Please ensure you're using a Private App access token, not a Personal Access Key or deprecated API key.";
+        const authMessage =
+          error ||
+          "Authentication failed. Please ensure you're using a Private App access token, not a Personal Access Key or deprecated API key.";
         throw new Error(`${authMessage} (${response.status})`);
       }
-      throw new Error(error ? `${error} (${response.status})` : `HubSpot API error: ${response.status}`);
+      throw new Error(
+        error ? `${error} (${response.status})` : `HubSpot API error: ${response.status}`
+      );
     }
 
     return response.json();
@@ -118,11 +127,14 @@ class HubSpotClient {
     if (!response.ok) {
       const error = await response.text();
       if (response.status === 401) {
-        const authMessage = error ||
-            "Authentication failed. Please ensure you're using a Private App access token, not a Personal Access Key or deprecated API key.";
+        const authMessage =
+          error ||
+          "Authentication failed. Please ensure you're using a Private App access token, not a Personal Access Key or deprecated API key.";
         throw new Error(`${authMessage} (${response.status})`);
       }
-      throw new Error(error ? `${error} (${response.status})` : `HubSpot API error: ${response.status}`);
+      throw new Error(
+        error ? `${error} (${response.status})` : `HubSpot API error: ${response.status}`
+      );
     }
 
     return response.json();


### PR DESCRIPTION
Updates the HubSpot connector to properly support Private App authentication and provide better error messages.

## Changes
- Update credential description to clarify Private App access tokens should be used
- Add specific 401 error handling with guidance about authentication methods
- Clarify that Personal Access Keys are only for local development tools
- Improve error messages to help users troubleshoot authentication issues

Closes #153

Generated with [Claude Code](https://claude.ai/code)
    
<!-- This is an auto-generated description by cubic. -->
---

## Summary by cubic
Update the HubSpot connector to use Private App access tokens and add clear 401 authentication guidance. Prevents misconfigured auth (e.g., Personal Access Keys or deprecated API keys) and makes troubleshooting easier. Closes #153.

- **Bug Fixes**
  - Added 401 handling with a message directing users to use a Private App access token.
  - Updated credential description; Personal Access Keys are for local dev tools only.
  - Improved error messages across API calls for clearer troubleshooting.

<!-- End of auto-generated description by cubic. -->

