### PR TITLE
fix: update Jira connector to use new JQL search endpoint

### DIFF
--- a/packages/mcp-connectors/src/connectors/jira.ts
+++ b/packages/mcp-connectors/src/connectors/jira.ts
@@ -440,7 +440,7 @@ class JiraClient {
     });
 
     const data = await this.fetchJson<JiraRawIssueResponse>(
-      `/rest/api/3/search?${params}`
+      `/rest/api/3/search/jql?${params}`
     );
 
     return {
@@ -471,7 +471,7 @@ class JiraClient {
     });
 
     const data = await this.fetchJson<JiraRawIssueResponse>(
-      `/rest/api/3/search?${params}`
+      `/rest/api/3/search/jql?${params}`
     );
 
     // Get comments for each child issue


### PR DESCRIPTION
This PR updates the Jira connector to replace the deprecated `/rest/api/3/search` endpoint with the new `/rest/api/3/search/jql` endpoint.

## Changes
- Updated `searchIssues()` method to use new JQL endpoint
- Updated `getEpicChildren()` method to use new JQL endpoint
- Maintained all existing functionality and parameters

Resolves #162

Generated with [Claude Code](https://claude.ai/code)
    
<!-- This is an auto-generated description by cubic. -->
---

## Summary by cubic
Migrated Jira connector searches (searchIssues and getEpicChildren) to /rest/api/3/search/jql to replace the deprecated /rest/api/3/search. Addresses Issue #162; behavior and parameters are unchanged.

<!-- End of auto-generated description by cubic. -->

