### PR TITLE
feat: add Harness connector and tests

### DIFF
--- a/packages/mcp-connectors/src/connectors/harness.spec.ts
+++ b/packages/mcp-connectors/src/connectors/harness.spec.ts
@@ -1,0 +1,860 @@
+import type { MCPToolDefinition } from '@stackone/mcp-config-types';
+import { http, HttpResponse } from 'msw';
+import { setupServer } from 'msw/node';
+import { describe, expect, it } from 'vitest';
+import { createMockConnectorContext } from '../__mocks__/context';
+import { HarnessConnectorConfig } from './harness';
+
+const server = setupServer();
+
+describe('#HarnessConnector', () => {
+  describe('.GET_FEATURE_FLAGS', () => {
+    describe('when request is successful', () => {
+      it('returns feature flags list', async () => {
+        const mockFeatureFlags = {
+          features: [
+            {
+              identifier: 'beta_features',
+              name: 'Beta Features Toggle',
+              description: 'Enable beta features for testing',
+              kind: 'boolean',
+              permanent: false,
+              tags: ['beta', 'testing'],
+              defaultServe: {
+                variation: 'true',
+              },
+              offVariation: 'false',
+              variations: [
+                {
+                  identifier: 'true',
+                  name: 'Enabled',
+                  value: true,
+                  description: 'Beta features enabled',
+                },
+                {
+                  identifier: 'false',
+                  name: 'Disabled',
+                  value: false,
+                  description: 'Beta features disabled',
+                },
+              ],
+              state: 'on',
+              createdAt: 1640995200000,
+              modifiedAt: 1640995200000,
+              version: 1,
+            },
+          ],
+        };
+
+        server.use(
+          http.get('https://app.harness.io/gateway/cf/admin/features', () => {
+            return HttpResponse.json(mockFeatureFlags);
+          })
+        );
+
+        server.listen();
+
+        const tool = HarnessConnectorConfig.tools.GET_FEATURE_FLAGS as MCPToolDefinition;
+        const mockContext = createMockConnectorContext({
+          credentials: {
+            apiKey: 'test-api-key',
+            accountId: 'test-account',
+            orgId: 'test-org',
+            projectId: 'test-project',
+          },
+        });
+
+        const actual = await tool.handler({ environmentId: 'production' }, mockContext);
+
+        expect(actual).toContain('"identifier": "beta_features"');
+        expect(actual).toContain('"name": "Beta Features Toggle"');
+        expect(actual).toContain('"kind": "boolean"');
+        expect(actual).toContain('"state": "on"');
+
+        server.close();
+      });
+    });
+
+    describe('when API returns error', () => {
+      it('returns error message', async () => {
+        server.use(
+          http.get('https://app.harness.io/gateway/cf/admin/features', () => {
+            return HttpResponse.json({ error: 'Unauthorized' }, { status: 401 });
+          })
+        );
+
+        server.listen();
+
+        const tool = HarnessConnectorConfig.tools.GET_FEATURE_FLAGS as MCPToolDefinition;
+        const mockContext = createMockConnectorContext({
+          credentials: {
+            apiKey: 'invalid-key',
+            accountId: 'test-account',
+            orgId: 'test-org',
+            projectId: 'test-project',
+          },
+        });
+
+        const actual = await tool.handler({ environmentId: 'production' }, mockContext);
+
+        expect(actual).toContain('Failed to get feature flags');
+        expect(actual).toContain('401');
+
+        server.close();
+      });
+    });
+  });
+
+  describe('.GET_FEATURE_FLAG', () => {
+    describe('when feature flag exists', () => {
+      it('returns detailed feature flag information', async () => {
+        const mockFeatureFlag = {
+          identifier: 'user_dashboard_v2',
+          name: 'User Dashboard V2',
+          description: 'New user dashboard design',
+          kind: 'boolean',
+          permanent: false,
+          tags: ['ui', 'dashboard'],
+          defaultServe: {
+            variation: 'false',
+          },
+          offVariation: 'false',
+          variations: [
+            {
+              identifier: 'true',
+              name: 'V2 Enabled',
+              value: true,
+              description: 'Show new dashboard',
+            },
+            {
+              identifier: 'false',
+              name: 'V2 Disabled',
+              value: false,
+              description: 'Show old dashboard',
+            },
+          ],
+          state: 'off',
+          envProperties: {
+            environment: 'production',
+            state: 'off',
+            defaultServe: {
+              variation: 'false',
+            },
+            offVariation: 'false',
+            modifiedAt: 1640995200000,
+            version: 3,
+          },
+          createdAt: 1640995200000,
+          modifiedAt: 1640995200000,
+          version: 3,
+        };
+
+        server.use(
+          http.get(
+            'https://app.harness.io/gateway/cf/admin/features/user_dashboard_v2',
+            () => {
+              return HttpResponse.json(mockFeatureFlag);
+            }
+          )
+        );
+
+        server.listen();
+
+        const tool = HarnessConnectorConfig.tools.GET_FEATURE_FLAG as MCPToolDefinition;
+        const mockContext = createMockConnectorContext({
+          credentials: {
+            apiKey: 'test-api-key',
+            accountId: 'test-account',
+            orgId: 'test-org',
+            projectId: 'test-project',
+          },
+        });
+
+        const actual = await tool.handler(
+          { flagIdentifier: 'user_dashboard_v2', environmentId: 'production' },
+          mockContext
+        );
+
+        expect(actual).toContain('"identifier": "user_dashboard_v2"');
+        expect(actual).toContain('"name": "User Dashboard V2"');
+        expect(actual).toContain('"envProperties"');
+        expect(actual).toContain('"version": 3');
+
+        server.close();
+      });
+    });
+
+    describe('when feature flag does not exist', () => {
+      it('returns error message', async () => {
+        server.use(
+          http.get(
+            'https://app.harness.io/gateway/cf/admin/features/nonexistent_flag',
+            () => {
+              return HttpResponse.json(
+                { error: 'Feature flag not found' },
+                { status: 404 }
+              );
+            }
+          )
+        );
+
+        server.listen();
+
+        const tool = HarnessConnectorConfig.tools.GET_FEATURE_FLAG as MCPToolDefinition;
+        const mockContext = createMockConnectorContext({
+          credentials: {
+            apiKey: 'test-api-key',
+            accountId: 'test-account',
+            orgId: 'test-org',
+            projectId: 'test-project',
+          },
+        });
+
+        const actual = await tool.handler(
+          { flagIdentifier: 'nonexistent_flag', environmentId: 'production' },
+          mockContext
+        );
+
+        expect(actual).toContain('Failed to get feature flag');
+        expect(actual).toContain('404');
+
+        server.close();
+      });
+    });
+  });
+
+  describe('.CREATE_FEATURE_FLAG', () => {
+    describe('when creation is successful', () => {
+      it('returns created feature flag', async () => {
+        const newFlag = {
+          identifier: 'mobile_dark_mode',
+          name: 'Mobile Dark Mode',
+          description: 'Dark mode toggle for mobile app',
+          kind: 'boolean',
+          permanent: false,
+          tags: ['mobile', 'ui'],
+          variations: [
+            {
+              identifier: 'enabled',
+              name: 'Dark Mode On',
+              value: true,
+              description: 'Dark mode is enabled',
+            },
+            {
+              identifier: 'disabled',
+              name: 'Dark Mode Off',
+              value: false,
+              description: 'Dark mode is disabled',
+            },
+          ],
+          defaultOnVariation: 'enabled',
+          defaultOffVariation: 'disabled',
+        };
+
+        const mockCreatedFlag = {
+          ...newFlag,
+          defaultServe: {
+            variation: 'disabled',
+          },
+          offVariation: 'disabled',
+          state: 'off',
+          createdAt: 1640995200000,
+          modifiedAt: 1640995200000,
+          version: 1,
+        };
+
+        server.use(
+          http.post('https://app.harness.io/gateway/cf/admin/features', () => {
+            return HttpResponse.json(mockCreatedFlag);
+          })
+        );
+
+        server.listen();
+
+        const tool = HarnessConnectorConfig.tools
+          .CREATE_FEATURE_FLAG as MCPToolDefinition;
+        const mockContext = createMockConnectorContext({
+          credentials: {
+            apiKey: 'test-api-key',
+            accountId: 'test-account',
+            orgId: 'test-org',
+            projectId: 'test-project',
+          },
+        });
+
+        const actual = await tool.handler(newFlag, mockContext);
+
+        expect(actual).toContain('"identifier": "mobile_dark_mode"');
+        expect(actual).toContain('"name": "Mobile Dark Mode"');
+        expect(actual).toContain('"kind": "boolean"');
+        expect(actual).toContain('"version": 1');
+
+        server.close();
+      });
+    });
+
+    describe('when creation fails due to validation', () => {
+      it('returns error message', async () => {
+        server.use(
+          http.post('https://app.harness.io/gateway/cf/admin/features', () => {
+            return HttpResponse.json(
+              { error: 'Invalid flag identifier', details: 'Identifier already exists' },
+              { status: 400 }
+            );
+          })
+        );
+
+        server.listen();
+
+        const tool = HarnessConnectorConfig.tools
+          .CREATE_FEATURE_FLAG as MCPToolDefinition;
+        const mockContext = createMockConnectorContext({
+          credentials: {
+            apiKey: 'test-api-key',
+            accountId: 'test-account',
+            orgId: 'test-org',
+            projectId: 'test-project',
+          },
+        });
+
+        const actual = await tool.handler(
+          {
+            identifier: 'existing_flag',
+            name: 'Existing Flag',
+            kind: 'boolean',
+            variations: [],
+            defaultOnVariation: 'on',
+            defaultOffVariation: 'off',
+          },
+          mockContext
+        );
+
+        expect(actual).toContain('Failed to create feature flag');
+        expect(actual).toContain('400');
+
+        server.close();
+      });
+    });
+  });
+
+  describe('.TOGGLE_FEATURE_FLAG', () => {
+    describe('when toggling to on', () => {
+      it('successfully enables the feature flag', async () => {
+        const mockUpdatedFlag = {
+          identifier: 'beta_features',
+          name: 'Beta Features Toggle',
+          state: 'on',
+          envProperties: {
+            environment: 'production',
+            state: 'on',
+            modifiedAt: 1640995200000,
+            version: 2,
+          },
+          version: 2,
+        };
+
+        server.use(
+          http.patch(
+            'https://app.harness.io/gateway/cf/admin/features/beta_features',
+            () => {
+              return HttpResponse.json(mockUpdatedFlag);
+            }
+          )
+        );
+
+        server.listen();
+
+        const tool = HarnessConnectorConfig.tools
+          .TOGGLE_FEATURE_FLAG as MCPToolDefinition;
+        const mockContext = createMockConnectorContext({
+          credentials: {
+            apiKey: 'test-api-key',
+            accountId: 'test-account',
+            orgId: 'test-org',
+            projectId: 'test-project',
+          },
+        });
+
+        const actual = await tool.handler(
+          { flagIdentifier: 'beta_features', environmentId: 'production', state: 'on' },
+          mockContext
+        );
+
+        expect(actual).toContain('"identifier": "beta_features"');
+        expect(actual).toContain('"state": "on"');
+        expect(actual).toContain('"version": 2');
+
+        server.close();
+      });
+    });
+
+    describe('when toggling to off', () => {
+      it('successfully disables the feature flag', async () => {
+        const mockUpdatedFlag = {
+          identifier: 'beta_features',
+          name: 'Beta Features Toggle',
+          state: 'off',
+          envProperties: {
+            environment: 'production',
+            state: 'off',
+            modifiedAt: 1640995200000,
+            version: 3,
+          },
+          version: 3,
+        };
+
+        server.use(
+          http.patch(
+            'https://app.harness.io/gateway/cf/admin/features/beta_features',
+            () => {
+              return HttpResponse.json(mockUpdatedFlag);
+            }
+          )
+        );
+
+        server.listen();
+
+        const tool = HarnessConnectorConfig.tools
+          .TOGGLE_FEATURE_FLAG as MCPToolDefinition;
+        const mockContext = createMockConnectorContext({
+          credentials: {
+            apiKey: 'test-api-key',
+            accountId: 'test-account',
+            orgId: 'test-org',
+            projectId: 'test-project',
+          },
+        });
+
+        const actual = await tool.handler(
+          { flagIdentifier: 'beta_features', environmentId: 'production', state: 'off' },
+          mockContext
+        );
+
+        expect(actual).toContain('"state": "off"');
+        expect(actual).toContain('"version": 3');
+
+        server.close();
+      });
+    });
+  });
+
+  describe('.UPDATE_FEATURE_FLAG', () => {
+    describe('when update is successful', () => {
+      it('returns updated feature flag with custom instructions', async () => {
+        const mockUpdatedFlag = {
+          identifier: 'user_dashboard_v2',
+          name: 'User Dashboard V2',
+          defaultServe: {
+            variation: 'true',
+          },
+          version: 4,
+        };
+
+        server.use(
+          http.patch(
+            'https://app.harness.io/gateway/cf/admin/features/user_dashboard_v2',
+            () => {
+              return HttpResponse.json(mockUpdatedFlag);
+            }
+          )
+        );
+
+        server.listen();
+
+        const tool = HarnessConnectorConfig.tools
+          .UPDATE_FEATURE_FLAG as MCPToolDefinition;
+        const mockContext = createMockConnectorContext({
+          credentials: {
+            apiKey: 'test-api-key',
+            accountId: 'test-account',
+            orgId: 'test-org',
+            projectId: 'test-project',
+          },
+        });
+
+        const actual = await tool.handler(
+          {
+            flagIdentifier: 'user_dashboard_v2',
+            environmentId: 'production',
+            instructions: [
+              {
+                kind: 'updateDefaultServe',
+                parameters: {
+                  variation: 'true',
+                },
+              },
+            ],
+          },
+          mockContext
+        );
+
+        expect(actual).toContain('"identifier": "user_dashboard_v2"');
+        expect(actual).toContain('"version": 4');
+
+        server.close();
+      });
+    });
+
+    describe('when update fails', () => {
+      it('returns error message', async () => {
+        server.use(
+          http.patch(
+            'https://app.harness.io/gateway/cf/admin/features/invalid_flag',
+            () => {
+              return HttpResponse.json({ error: 'Invalid instruction' }, { status: 400 });
+            }
+          )
+        );
+
+        server.listen();
+
+        const tool = HarnessConnectorConfig.tools
+          .UPDATE_FEATURE_FLAG as MCPToolDefinition;
+        const mockContext = createMockConnectorContext({
+          credentials: {
+            apiKey: 'test-api-key',
+            accountId: 'test-account',
+            orgId: 'test-org',
+            projectId: 'test-project',
+          },
+        });
+
+        const actual = await tool.handler(
+          {
+            flagIdentifier: 'invalid_flag',
+            environmentId: 'production',
+            instructions: [{ kind: 'invalidInstruction' }],
+          },
+          mockContext
+        );
+
+        expect(actual).toContain('Failed to update feature flag');
+        expect(actual).toContain('400');
+
+        server.close();
+      });
+    });
+  });
+
+  describe('.DELETE_FEATURE_FLAG', () => {
+    describe('when deletion is successful', () => {
+      it('returns success message', async () => {
+        server.use(
+          http.delete(
+            'https://app.harness.io/gateway/cf/admin/features/old_feature',
+            () => {
+              return HttpResponse.json({}, { status: 204 });
+            }
+          )
+        );
+
+        server.listen();
+
+        const tool = HarnessConnectorConfig.tools
+          .DELETE_FEATURE_FLAG as MCPToolDefinition;
+        const mockContext = createMockConnectorContext({
+          credentials: {
+            apiKey: 'test-api-key',
+            accountId: 'test-account',
+            orgId: 'test-org',
+            projectId: 'test-project',
+          },
+        });
+
+        const actual = await tool.handler({ flagIdentifier: 'old_feature' }, mockContext);
+
+        expect(actual).toContain('Feature flag old_feature deleted successfully');
+
+        server.close();
+      });
+    });
+
+    describe('when flag does not exist', () => {
+      it('returns error message', async () => {
+        server.use(
+          http.delete(
+            'https://app.harness.io/gateway/cf/admin/features/nonexistent_flag',
+            () => {
+              return HttpResponse.json(
+                { error: 'Feature flag not found' },
+                { status: 404 }
+              );
+            }
+          )
+        );
+
+        server.listen();
+
+        const tool = HarnessConnectorConfig.tools
+          .DELETE_FEATURE_FLAG as MCPToolDefinition;
+        const mockContext = createMockConnectorContext({
+          credentials: {
+            apiKey: 'test-api-key',
+            accountId: 'test-account',
+            orgId: 'test-org',
+            projectId: 'test-project',
+          },
+        });
+
+        const actual = await tool.handler(
+          { flagIdentifier: 'nonexistent_flag' },
+          mockContext
+        );
+
+        expect(actual).toContain('Failed to delete feature flag');
+        expect(actual).toContain('404');
+
+        server.close();
+      });
+    });
+  });
+
+  describe('.GET_TARGETS', () => {
+    describe('when request is successful', () => {
+      it('returns targets list', async () => {
+        const mockTargets = {
+          targets: [
+            {
+              identifier: 'user_123',
+              account: 'test-account',
+              org: 'test-org',
+              environment: 'production',
+              project: 'test-project',
+              name: 'John Doe',
+              anonymous: false,
+              attributes: {
+                email: 'john@example.com',
+                plan: 'premium',
+                region: 'us-east-1',
+              },
+              createdAt: 1640995200000,
+            },
+          ],
+        };
+
+        server.use(
+          http.get('https://app.harness.io/gateway/cf/admin/targets', () => {
+            return HttpResponse.json(mockTargets);
+          })
+        );
+
+        server.listen();
+
+        const tool = HarnessConnectorConfig.tools.GET_TARGETS as MCPToolDefinition;
+        const mockContext = createMockConnectorContext({
+          credentials: {
+            apiKey: 'test-api-key',
+            accountId: 'test-account',
+            orgId: 'test-org',
+            projectId: 'test-project',
+          },
+        });
+
+        const actual = await tool.handler({ environmentId: 'production' }, mockContext);
+
+        expect(actual).toContain('"identifier": "user_123"');
+        expect(actual).toContain('"name": "John Doe"');
+        expect(actual).toContain('"email": "john@example.com"');
+        expect(actual).toContain('"plan": "premium"');
+
+        server.close();
+      });
+    });
+
+    describe('when API returns empty results', () => {
+      it('returns empty targets array', async () => {
+        const mockTargets = {
+          targets: [],
+        };
+
+        server.use(
+          http.get('https://app.harness.io/gateway/cf/admin/targets', () => {
+            return HttpResponse.json(mockTargets);
+          })
+        );
+
+        server.listen();
+
+        const tool = HarnessConnectorConfig.tools.GET_TARGETS as MCPToolDefinition;
+        const mockContext = createMockConnectorContext({
+          credentials: {
+            apiKey: 'test-api-key',
+            accountId: 'test-account',
+            orgId: 'test-org',
+            projectId: 'test-project',
+          },
+        });
+
+        const actual = await tool.handler({ environmentId: 'production' }, mockContext);
+
+        expect(actual).toContain('"targets": []');
+
+        server.close();
+      });
+    });
+  });
+
+  describe('.GET_TARGET_GROUPS', () => {
+    describe('when request is successful', () => {
+      it('returns target groups list', async () => {
+        const mockTargetGroups = {
+          targetGroups: [
+            {
+              identifier: 'premium_users',
+              name: 'Premium Users',
+              environment: 'production',
+              project: 'test-project',
+              account: 'test-account',
+              org: 'test-org',
+              description: 'Users with premium subscriptions',
+              tags: ['premium', 'subscription'],
+              rules: [
+                {
+                  attribute: 'plan',
+                  op: 'equal',
+                  values: ['premium', 'enterprise'],
+                },
+              ],
+              createdAt: 1640995200000,
+              modifiedAt: 1640995200000,
+              version: 1,
+            },
+          ],
+        };
+
+        server.use(
+          http.get('https://app.harness.io/gateway/cf/admin/target-groups', () => {
+            return HttpResponse.json(mockTargetGroups);
+          })
+        );
+
+        server.listen();
+
+        const tool = HarnessConnectorConfig.tools.GET_TARGET_GROUPS as MCPToolDefinition;
+        const mockContext = createMockConnectorContext({
+          credentials: {
+            apiKey: 'test-api-key',
+            accountId: 'test-account',
+            orgId: 'test-org',
+            projectId: 'test-project',
+          },
+        });
+
+        const actual = await tool.handler({ environmentId: 'production' }, mockContext);
+
+        expect(actual).toContain('"identifier": "premium_users"');
+        expect(actual).toContain('"name": "Premium Users"');
+        expect(actual).toContain('"description": "Users with premium subscriptions"');
+        expect(actual).toContain('"rules"');
+
+        server.close();
+      });
+    });
+  });
+
+  describe('.GET_FEATURE_FLAG_METRICS', () => {
+    describe('when request is successful', () => {
+      it('returns feature flag metrics and analytics', async () => {
+        const mockMetrics = {
+          flagIdentifier: 'user_dashboard_v2',
+          environment: 'production',
+          variationMetrics: [
+            {
+              variation: 'true',
+              count: 15420,
+              percentage: 23.5,
+            },
+            {
+              variation: 'false',
+              count: 50180,
+              percentage: 76.5,
+            },
+          ],
+          totalEvaluations: 65600,
+        };
+
+        server.use(
+          http.get(
+            'https://app.harness.io/gateway/cf/admin/metrics/flags/user_dashboard_v2',
+            () => {
+              return HttpResponse.json(mockMetrics);
+            }
+          )
+        );
+
+        server.listen();
+
+        const tool = HarnessConnectorConfig.tools
+          .GET_FEATURE_FLAG_METRICS as MCPToolDefinition;
+        const mockContext = createMockConnectorContext({
+          credentials: {
+            apiKey: 'test-api-key',
+            accountId: 'test-account',
+            orgId: 'test-org',
+            projectId: 'test-project',
+          },
+        });
+
+        const actual = await tool.handler(
+          {
+            flagIdentifier: 'user_dashboard_v2',
+            environmentId: 'production',
+            fromTimestamp: 1640995200000,
+            toTimestamp: 1641081600000,
+          },
+          mockContext
+        );
+
+        expect(actual).toContain('"flagIdentifier": "user_dashboard_v2"');
+        expect(actual).toContain('"totalEvaluations": 65600');
+        expect(actual).toContain('"variationMetrics"');
+        expect(actual).toContain('"percentage": 23.5');
+
+        server.close();
+      });
+    });
+
+    describe('when flag has no metrics', () => {
+      it('returns empty metrics', async () => {
+        const mockMetrics = {
+          flagIdentifier: 'new_feature',
+          environment: 'production',
+          variationMetrics: [],
+          totalEvaluations: 0,
+        };
+
+        server.use(
+          http.get(
+            'https://app.harness.io/gateway/cf/admin/metrics/flags/new_feature',
+            () => {
+              return HttpResponse.json(mockMetrics);
+            }
+          )
+        );
+
+        server.listen();
+
+        const tool = HarnessConnectorConfig.tools
+          .GET_FEATURE_FLAG_METRICS as MCPToolDefinition;
+        const mockContext = createMockConnectorContext({
+          credentials: {
+            apiKey: 'test-api-key',
+            accountId: 'test-account',
+            orgId: 'test-org',
+            projectId: 'test-project',
+          },
+        });
+
+        const actual = await tool.handler(
+          { flagIdentifier: 'new_feature', environmentId: 'production' },
+          mockContext
+        );
+
+        expect(actual).toContain('"totalEvaluations": 0');
+        expect(actual).toContain('"variationMetrics": []');
+
+        server.close();
+      });
+    });
+  });
+});

--- a/packages/mcp-connectors/src/connectors/harness.ts
+++ b/packages/mcp-connectors/src/connectors/harness.ts
@@ -1,0 +1,526 @@
+import { mcpConnectorConfig } from '@stackone/mcp-config-types';
+import { z } from 'zod';
+
+interface HarnessFeatureFlag {
+  identifier: string;
+  name: string;
+  description?: string;
+  kind: 'boolean' | 'int' | 'string' | 'json';
+  permanent: boolean;
+  tags?: string[];
+  defaultServe: {
+    variation: string;
+  };
+  offVariation: string;
+  variations: Array<{
+    identifier: string;
+    name: string;
+    value: string | boolean | number | object;
+    description?: string;
+  }>;
+  prerequisites?: Array<{
+    flag: string;
+    variations: string[];
+  }>;
+  state: 'on' | 'off';
+  envProperties?: {
+    environment: string;
+    state: 'on' | 'off';
+    defaultServe: {
+      variation: string;
+    };
+    offVariation: string;
+    modifiedAt: number;
+    version: number;
+  };
+  createdAt: number;
+  modifiedAt: number;
+  version: number;
+  [key: string]: unknown;
+}
+
+interface HarnessTarget {
+  identifier: string;
+  account: string;
+  org: string;
+  environment: string;
+  project: string;
+  name: string;
+  anonymous?: boolean;
+  attributes?: Record<string, string>;
+  createdAt?: number;
+  segments?: Array<{
+    identifier: string;
+    name: string;
+  }>;
+  [key: string]: unknown;
+}
+
+interface HarnessTargetGroup {
+  identifier: string;
+  name: string;
+  environment: string;
+  project: string;
+  account: string;
+  org: string;
+  description?: string;
+  tags?: string[];
+  includedTargets?: Array<{
+    identifier: string;
+    name: string;
+  }>;
+  excludedTargets?: Array<{
+    identifier: string;
+    name: string;
+  }>;
+  rules?: Array<{
+    attribute: string;
+    op: string;
+    values: string[];
+  }>;
+  createdAt: number;
+  modifiedAt: number;
+  version: number;
+  [key: string]: unknown;
+}
+
+interface HarnessMetrics {
+  flagIdentifier: string;
+  environment: string;
+  variationMetrics: Array<{
+    variation: string;
+    count: number;
+    percentage: number;
+  }>;
+  totalEvaluations: number;
+  [key: string]: unknown;
+}
+
+class HarnessClient {
+  private baseUrl: string;
+  private headers: {
+    Authorization: string;
+    'Content-Type': string;
+    'Harness-Account': string;
+  };
+  private accountId: string;
+  private orgId: string;
+  private projectId: string;
+
+  constructor(apiKey: string, accountId: string, orgId: string, projectId: string) {
+    this.baseUrl = 'https://app.harness.io/gateway/cf/admin';
+    this.accountId = accountId;
+    this.orgId = orgId;
+    this.projectId = projectId;
+    this.headers = {
+      Authorization: `Bearer ${apiKey}`,
+      'Content-Type': 'application/json',
+      'Harness-Account': accountId,
+    };
+  }
+
+  private async makeRequest(
+    endpoint: string,
+    method: 'GET' | 'POST' | 'PUT' | 'PATCH' | 'DELETE' = 'GET',
+    body?: unknown
+  ): Promise<unknown> {
+    const url = `${this.baseUrl}${endpoint}`;
+    const options: RequestInit = {
+      method,
+      headers: this.headers,
+    };
+
+    if (body && (method === 'POST' || method === 'PUT' || method === 'PATCH')) {
+      options.body = JSON.stringify(body);
+    }
+
+    const response = await fetch(url, options);
+
+    if (!response.ok) {
+      throw new Error(`Harness API error: ${response.status} ${response.statusText}`);
+    }
+
+    return response.json();
+  }
+
+  async getFeatureFlags(
+    environmentId: string
+  ): Promise<{ features: HarnessFeatureFlag[] }> {
+    const endpoint = `/features?accountIdentifier=${this.accountId}&orgIdentifier=${this.orgId}&projectIdentifier=${this.projectId}&environmentIdentifier=${environmentId}`;
+    return (await this.makeRequest(endpoint)) as { features: HarnessFeatureFlag[] };
+  }
+
+  async getFeatureFlag(
+    flagIdentifier: string,
+    environmentId: string
+  ): Promise<HarnessFeatureFlag> {
+    const endpoint = `/features/${flagIdentifier}?accountIdentifier=${this.accountId}&orgIdentifier=${this.orgId}&projectIdentifier=${this.projectId}&environmentIdentifier=${environmentId}`;
+    return (await this.makeRequest(endpoint)) as HarnessFeatureFlag;
+  }
+
+  async createFeatureFlag(flagData: {
+    identifier: string;
+    name: string;
+    description?: string;
+    kind: 'boolean' | 'int' | 'string' | 'json';
+    permanent?: boolean;
+    tags?: string[];
+    variations: Array<{
+      identifier: string;
+      name: string;
+      value: string | boolean | number | object;
+      description?: string;
+    }>;
+    defaultOnVariation: string;
+    defaultOffVariation: string;
+  }): Promise<HarnessFeatureFlag> {
+    const endpoint = `/features?accountIdentifier=${this.accountId}&orgIdentifier=${this.orgId}&projectIdentifier=${this.projectId}`;
+    return (await this.makeRequest(endpoint, 'POST', flagData)) as HarnessFeatureFlag;
+  }
+
+  async updateFeatureFlag(
+    flagIdentifier: string,
+    environmentId: string,
+    instructions: Array<{
+      kind: string;
+      parameters?: Record<string, unknown>;
+    }>
+  ): Promise<HarnessFeatureFlag> {
+    const endpoint = `/features/${flagIdentifier}?accountIdentifier=${this.accountId}&orgIdentifier=${this.orgId}&projectIdentifier=${this.projectId}&environmentIdentifier=${environmentId}`;
+    return (await this.makeRequest(endpoint, 'PATCH', {
+      instructions,
+    })) as HarnessFeatureFlag;
+  }
+
+  async toggleFeatureFlag(
+    flagIdentifier: string,
+    environmentId: string,
+    state: 'on' | 'off'
+  ): Promise<HarnessFeatureFlag> {
+    const instruction = {
+      kind: state === 'on' ? 'setFeatureFlagState' : 'setFeatureFlagState',
+      parameters: {
+        state,
+      },
+    };
+    return this.updateFeatureFlag(flagIdentifier, environmentId, [instruction]);
+  }
+
+  async deleteFeatureFlag(flagIdentifier: string): Promise<void> {
+    const endpoint = `/features/${flagIdentifier}?accountIdentifier=${this.accountId}&orgIdentifier=${this.orgId}&projectIdentifier=${this.projectId}`;
+    const response = await fetch(`${this.baseUrl}${endpoint}`, {
+      method: 'DELETE',
+      headers: this.headers,
+    });
+
+    if (!response.ok) {
+      throw new Error(`Harness API error: ${response.status} ${response.statusText}`);
+    }
+  }
+
+  async getTargets(environmentId: string): Promise<{ targets: HarnessTarget[] }> {
+    const endpoint = `/targets?accountIdentifier=${this.accountId}&orgIdentifier=${this.orgId}&projectIdentifier=${this.projectId}&environmentIdentifier=${environmentId}`;
+    return (await this.makeRequest(endpoint)) as { targets: HarnessTarget[] };
+  }
+
+  async getTargetGroups(
+    environmentId: string
+  ): Promise<{ targetGroups: HarnessTargetGroup[] }> {
+    const endpoint = `/target-groups?accountIdentifier=${this.accountId}&orgIdentifier=${this.orgId}&projectIdentifier=${this.projectId}&environmentIdentifier=${environmentId}`;
+    return (await this.makeRequest(endpoint)) as { targetGroups: HarnessTargetGroup[] };
+  }
+
+  async getFeatureFlagMetrics(
+    flagIdentifier: string,
+    environmentId: string,
+    fromTimestamp?: number,
+    toTimestamp?: number
+  ): Promise<HarnessMetrics> {
+    let endpoint = `/metrics/flags/${flagIdentifier}?accountIdentifier=${this.accountId}&orgIdentifier=${this.orgId}&projectIdentifier=${this.projectId}&environmentIdentifier=${environmentId}`;
+
+    if (fromTimestamp) {
+      endpoint += `&from=${fromTimestamp}`;
+    }
+    if (toTimestamp) {
+      endpoint += `&to=${toTimestamp}`;
+    }
+
+    return (await this.makeRequest(endpoint)) as HarnessMetrics;
+  }
+}
+
+export const HarnessConnectorConfig = mcpConnectorConfig({
+  name: 'Harness',
+  key: 'harness',
+  version: '1.0.0',
+  logo: 'https://stackone-logos.com/api/harness/filled/svg',
+  credentials: z.object({
+    apiKey: z
+      .string()
+      .describe(
+        'Harness API Key from Personal Access Tokens :: har_platform_1234567890abcdef :: https://developer.harness.io/docs/platform/automation/api/add-and-manage-api-keys/'
+      ),
+    accountId: z
+      .string()
+      .describe(
+        'Harness Account Identifier :: wlgELJ0TTre5aZhzpt8gVA :: Found in Account Settings'
+      ),
+    orgId: z
+      .string()
+      .describe(
+        'Harness Organization Identifier :: default :: Found in Organization Settings'
+      ),
+    projectId: z
+      .string()
+      .describe(
+        'Harness Project Identifier :: default_project :: Found in Project Settings'
+      ),
+  }),
+  setup: z.object({}),
+  examplePrompt:
+    'Get all feature flags in the production environment, toggle the beta_features flag to on, check the usage metrics for user_dashboard_v2 flag, and create a new feature flag for the mobile app.',
+  tools: (tool) => ({
+    GET_FEATURE_FLAGS: tool({
+      name: 'harness_get_feature_flags',
+      description: 'Get all feature flags for a specific environment',
+      schema: z.object({
+        environmentId: z
+          .string()
+          .describe('Environment identifier (e.g., production, staging, dev)'),
+      }),
+      handler: async (args, context) => {
+        try {
+          const { apiKey, accountId, orgId, projectId } = await context.getCredentials();
+          const client = new HarnessClient(apiKey, accountId, orgId, projectId);
+          const result = await client.getFeatureFlags(args.environmentId);
+          return JSON.stringify(result, null, 2);
+        } catch (error) {
+          return `Failed to get feature flags: ${error instanceof Error ? error.message : String(error)}`;
+        }
+      },
+    }),
+
+    GET_FEATURE_FLAG: tool({
+      name: 'harness_get_feature_flag',
+      description: 'Get detailed information about a specific feature flag',
+      schema: z.object({
+        flagIdentifier: z.string().describe('Feature flag identifier'),
+        environmentId: z
+          .string()
+          .describe('Environment identifier (e.g., production, staging, dev)'),
+      }),
+      handler: async (args, context) => {
+        try {
+          const { apiKey, accountId, orgId, projectId } = await context.getCredentials();
+          const client = new HarnessClient(apiKey, accountId, orgId, projectId);
+          const result = await client.getFeatureFlag(
+            args.flagIdentifier,
+            args.environmentId
+          );
+          return JSON.stringify(result, null, 2);
+        } catch (error) {
+          return `Failed to get feature flag: ${error instanceof Error ? error.message : String(error)}`;
+        }
+      },
+    }),
+
+    CREATE_FEATURE_FLAG: tool({
+      name: 'harness_create_feature_flag',
+      description: 'Create a new feature flag',
+      schema: z.object({
+        identifier: z.string().describe('Unique feature flag identifier'),
+        name: z.string().describe('Human-readable feature flag name'),
+        description: z.string().optional().describe('Feature flag description'),
+        kind: z
+          .enum(['boolean', 'int', 'string', 'json'])
+          .describe('Type of feature flag'),
+        permanent: z.boolean().optional().describe('Whether the flag is permanent'),
+        tags: z.array(z.string()).optional().describe('Tags for organizing flags'),
+        variations: z
+          .array(
+            z.object({
+              identifier: z.string().describe('Variation identifier'),
+              name: z.string().describe('Variation name'),
+              value: z
+                .union([z.string(), z.boolean(), z.number(), z.object({})])
+                .describe('Variation value'),
+              description: z.string().optional().describe('Variation description'),
+            })
+          )
+          .describe('Available variations for the flag'),
+        defaultOnVariation: z.string().describe('Default variation when flag is on'),
+        defaultOffVariation: z.string().describe('Default variation when flag is off'),
+      }),
+      handler: async (args, context) => {
+        try {
+          const { apiKey, accountId, orgId, projectId } = await context.getCredentials();
+          const client = new HarnessClient(apiKey, accountId, orgId, projectId);
+          const result = await client.createFeatureFlag(args);
+          return JSON.stringify(result, null, 2);
+        } catch (error) {
+          return `Failed to create feature flag: ${error instanceof Error ? error.message : String(error)}`;
+        }
+      },
+    }),
+
+    TOGGLE_FEATURE_FLAG: tool({
+      name: 'harness_toggle_feature_flag',
+      description: 'Turn a feature flag on or off in a specific environment',
+      schema: z.object({
+        flagIdentifier: z.string().describe('Feature flag identifier'),
+        environmentId: z
+          .string()
+          .describe('Environment identifier (e.g., production, staging, dev)'),
+        state: z.enum(['on', 'off']).describe('New state for the feature flag'),
+      }),
+      handler: async (args, context) => {
+        try {
+          const { apiKey, accountId, orgId, projectId } = await context.getCredentials();
+          const client = new HarnessClient(apiKey, accountId, orgId, projectId);
+          const result = await client.toggleFeatureFlag(
+            args.flagIdentifier,
+            args.environmentId,
+            args.state
+          );
+          return JSON.stringify(result, null, 2);
+        } catch (error) {
+          return `Failed to toggle feature flag: ${error instanceof Error ? error.message : String(error)}`;
+        }
+      },
+    }),
+
+    UPDATE_FEATURE_FLAG: tool({
+      name: 'harness_update_feature_flag',
+      description: 'Update a feature flag with custom instructions',
+      schema: z.object({
+        flagIdentifier: z.string().describe('Feature flag identifier'),
+        environmentId: z
+          .string()
+          .describe('Environment identifier (e.g., production, staging, dev)'),
+        instructions: z
+          .array(
+            z.object({
+              kind: z
+                .string()
+                .describe(
+                  'Type of instruction (e.g., setFeatureFlagState, updateDefaultServe)'
+                ),
+              parameters: z
+                .record(z.unknown())
+                .optional()
+                .describe('Parameters for the instruction'),
+            })
+          )
+          .describe('Array of update instructions'),
+      }),
+      handler: async (args, context) => {
+        try {
+          const { apiKey, accountId, orgId, projectId } = await context.getCredentials();
+          const client = new HarnessClient(apiKey, accountId, orgId, projectId);
+          const result = await client.updateFeatureFlag(
+            args.flagIdentifier,
+            args.environmentId,
+            args.instructions
+          );
+          return JSON.stringify(result, null, 2);
+        } catch (error) {
+          return `Failed to update feature flag: ${error instanceof Error ? error.message : String(error)}`;
+        }
+      },
+    }),
+
+    DELETE_FEATURE_FLAG: tool({
+      name: 'harness_delete_feature_flag',
+      description: 'Delete a feature flag (use with caution)',
+      schema: z.object({
+        flagIdentifier: z.string().describe('Feature flag identifier to delete'),
+      }),
+      handler: async (args, context) => {
+        try {
+          const { apiKey, accountId, orgId, projectId } = await context.getCredentials();
+          const client = new HarnessClient(apiKey, accountId, orgId, projectId);
+          await client.deleteFeatureFlag(args.flagIdentifier);
+          return `Feature flag ${args.flagIdentifier} deleted successfully`;
+        } catch (error) {
+          return `Failed to delete feature flag: ${error instanceof Error ? error.message : String(error)}`;
+        }
+      },
+    }),
+
+    GET_TARGETS: tool({
+      name: 'harness_get_targets',
+      description:
+        'Get all targets (users/entities) for feature flag evaluation in an environment',
+      schema: z.object({
+        environmentId: z
+          .string()
+          .describe('Environment identifier (e.g., production, staging, dev)'),
+      }),
+      handler: async (args, context) => {
+        try {
+          const { apiKey, accountId, orgId, projectId } = await context.getCredentials();
+          const client = new HarnessClient(apiKey, accountId, orgId, projectId);
+          const result = await client.getTargets(args.environmentId);
+          return JSON.stringify(result, null, 2);
+        } catch (error) {
+          return `Failed to get targets: ${error instanceof Error ? error.message : String(error)}`;
+        }
+      },
+    }),
+
+    GET_TARGET_GROUPS: tool({
+      name: 'harness_get_target_groups',
+      description:
+        'Get all target groups (segments) for feature flag targeting in an environment',
+      schema: z.object({
+        environmentId: z
+          .string()
+          .describe('Environment identifier (e.g., production, staging, dev)'),
+      }),
+      handler: async (args, context) => {
+        try {
+          const { apiKey, accountId, orgId, projectId } = await context.getCredentials();
+          const client = new HarnessClient(apiKey, accountId, orgId, projectId);
+          const result = await client.getTargetGroups(args.environmentId);
+          return JSON.stringify(result, null, 2);
+        } catch (error) {
+          return `Failed to get target groups: ${error instanceof Error ? error.message : String(error)}`;
+        }
+      },
+    }),
+
+    GET_FEATURE_FLAG_METRICS: tool({
+      name: 'harness_get_feature_flag_metrics',
+      description: 'Get usage metrics and analytics for a specific feature flag',
+      schema: z.object({
+        flagIdentifier: z.string().describe('Feature flag identifier'),
+        environmentId: z
+          .string()
+          .describe('Environment identifier (e.g., production, staging, dev)'),
+        fromTimestamp: z
+          .number()
+          .optional()
+          .describe('Start timestamp for metrics (Unix timestamp in milliseconds)'),
+        toTimestamp: z
+          .number()
+          .optional()
+          .describe('End timestamp for metrics (Unix timestamp in milliseconds)'),
+      }),
+      handler: async (args, context) => {
+        try {
+          const { apiKey, accountId, orgId, projectId } = await context.getCredentials();
+          const client = new HarnessClient(apiKey, accountId, orgId, projectId);
+          const result = await client.getFeatureFlagMetrics(
+            args.flagIdentifier,
+            args.environmentId,
+            args.fromTimestamp,
+            args.toTimestamp
+          );
+          return JSON.stringify(result, null, 2);
+        } catch (error) {
+          return `Failed to get feature flag metrics: ${error instanceof Error ? error.message : String(error)}`;
+        }
+      },
+    }),
+  }),
+});

--- a/packages/mcp-connectors/src/index.ts
+++ b/packages/mcp-connectors/src/index.ts
@@ -18,6 +18,7 @@ import { GitLabConnectorConfig } from './connectors/gitlab';
 import { GoogleDriveConnectorConfig } from './connectors/google-drive';
 import { googleMapsConnector as GoogleMapsConnectorConfig } from './connectors/google-maps';
 import { GraphyConnectorConfig } from './connectors/graphy';
+import { HarnessConnectorConfig } from './connectors/harness';
 import { HiBobConnectorConfig } from './connectors/hibob';
 import { HubSpotConnectorConfig } from './connectors/hubspot';
 import { IncidentConnectorConfig } from './connectors/incident';
@@ -71,6 +72,7 @@ export const Connectors: readonly MCPConnectorConfig[] = [
   GoogleDriveConnectorConfig,
   GoogleMapsConnectorConfig,
   GraphyConnectorConfig,
+  HarnessConnectorConfig,
   HiBobConnectorConfig,
   HubSpotConnectorConfig,
   IncidentConnectorConfig,
@@ -124,6 +126,7 @@ export {
   GoogleDriveConnectorConfig,
   GoogleMapsConnectorConfig,
   GraphyConnectorConfig,
+  HarnessConnectorConfig,
   HiBobConnectorConfig,
   HubSpotConnectorConfig,
   IncidentConnectorConfig,


### PR DESCRIPTION
- Introduced the Harness connector with functionalities for managing feature flags, targets, and target groups.
- Implemented comprehensive tests for the Harness connector, covering various scenarios including feature flag retrieval, creation, updating, and deletion.
- Updated index to include the new HarnessConnectorConfig for integration with the MCP framework.
    
<!-- This is an auto-generated description by cubic. -->
---

## Summary by cubic
Adds a Harness connector for MCP to manage feature flags, targets, target groups, and metrics. Includes comprehensive tests and registers the connector in the MCP connectors index.

- **New Features**
  - HarnessConnectorConfig with feature flag tools: get, create, update, toggle, and delete.
  - Targeting tools: fetch targets and target groups by environment.
  - Metrics tool: fetch feature flag usage metrics with optional time range.
  - Connector registered in packages/mcp-connectors index for MCP consumption.

<!-- End of auto-generated description by cubic. -->

