### PR TITLE
feat: luma server

### DIFF
--- a/packages/mcp-connectors/src/connectors/harness.spec.ts
+++ b/packages/mcp-connectors/src/connectors/harness.spec.ts
@@ -1,0 +1,860 @@
+import type { MCPToolDefinition } from '@stackone/mcp-config-types';
+import { http, HttpResponse } from 'msw';
+import { setupServer } from 'msw/node';
+import { describe, expect, it } from 'vitest';
+import { createMockConnectorContext } from '../__mocks__/context';
+import { HarnessConnectorConfig } from './harness';
+
+const server = setupServer();
+
+describe('#HarnessConnector', () => {
+  describe('.GET_FEATURE_FLAGS', () => {
+    describe('when request is successful', () => {
+      it('returns feature flags list', async () => {
+        const mockFeatureFlags = {
+          features: [
+            {
+              identifier: 'beta_features',
+              name: 'Beta Features Toggle',
+              description: 'Enable beta features for testing',
+              kind: 'boolean',
+              permanent: false,
+              tags: ['beta', 'testing'],
+              defaultServe: {
+                variation: 'true',
+              },
+              offVariation: 'false',
+              variations: [
+                {
+                  identifier: 'true',
+                  name: 'Enabled',
+                  value: true,
+                  description: 'Beta features enabled',
+                },
+                {
+                  identifier: 'false',
+                  name: 'Disabled',
+                  value: false,
+                  description: 'Beta features disabled',
+                },
+              ],
+              state: 'on',
+              createdAt: 1640995200000,
+              modifiedAt: 1640995200000,
+              version: 1,
+            },
+          ],
+        };
+
+        server.use(
+          http.get('https://app.harness.io/gateway/cf/admin/features', () => {
+            return HttpResponse.json(mockFeatureFlags);
+          })
+        );
+
+        server.listen();
+
+        const tool = HarnessConnectorConfig.tools.GET_FEATURE_FLAGS as MCPToolDefinition;
+        const mockContext = createMockConnectorContext({
+          credentials: {
+            apiKey: 'test-api-key',
+            accountId: 'test-account',
+            orgId: 'test-org',
+            projectId: 'test-project',
+          },
+        });
+
+        const actual = await tool.handler({ environmentId: 'production' }, mockContext);
+
+        expect(actual).toContain('"identifier": "beta_features"');
+        expect(actual).toContain('"name": "Beta Features Toggle"');
+        expect(actual).toContain('"kind": "boolean"');
+        expect(actual).toContain('"state": "on"');
+
+        server.close();
+      });
+    });
+
+    describe('when API returns error', () => {
+      it('returns error message', async () => {
+        server.use(
+          http.get('https://app.harness.io/gateway/cf/admin/features', () => {
+            return HttpResponse.json({ error: 'Unauthorized' }, { status: 401 });
+          })
+        );
+
+        server.listen();
+
+        const tool = HarnessConnectorConfig.tools.GET_FEATURE_FLAGS as MCPToolDefinition;
+        const mockContext = createMockConnectorContext({
+          credentials: {
+            apiKey: 'invalid-key',
+            accountId: 'test-account',
+            orgId: 'test-org',
+            projectId: 'test-project',
+          },
+        });
+
+        const actual = await tool.handler({ environmentId: 'production' }, mockContext);
+
+        expect(actual).toContain('Failed to get feature flags');
+        expect(actual).toContain('401');
+
+        server.close();
+      });
+    });
+  });
+
+  describe('.GET_FEATURE_FLAG', () => {
+    describe('when feature flag exists', () => {
+      it('returns detailed feature flag information', async () => {
+        const mockFeatureFlag = {
+          identifier: 'user_dashboard_v2',
+          name: 'User Dashboard V2',
+          description: 'New user dashboard design',
+          kind: 'boolean',
+          permanent: false,
+          tags: ['ui', 'dashboard'],
+          defaultServe: {
+            variation: 'false',
+          },
+          offVariation: 'false',
+          variations: [
+            {
+              identifier: 'true',
+              name: 'V2 Enabled',
+              value: true,
+              description: 'Show new dashboard',
+            },
+            {
+              identifier: 'false',
+              name: 'V2 Disabled',
+              value: false,
+              description: 'Show old dashboard',
+            },
+          ],
+          state: 'off',
+          envProperties: {
+            environment: 'production',
+            state: 'off',
+            defaultServe: {
+              variation: 'false',
+            },
+            offVariation: 'false',
+            modifiedAt: 1640995200000,
+            version: 3,
+          },
+          createdAt: 1640995200000,
+          modifiedAt: 1640995200000,
+          version: 3,
+        };
+
+        server.use(
+          http.get(
+            'https://app.harness.io/gateway/cf/admin/features/user_dashboard_v2',
+            () => {
+              return HttpResponse.json(mockFeatureFlag);
+            }
+          )
+        );
+
+        server.listen();
+
+        const tool = HarnessConnectorConfig.tools.GET_FEATURE_FLAG as MCPToolDefinition;
+        const mockContext = createMockConnectorContext({
+          credentials: {
+            apiKey: 'test-api-key',
+            accountId: 'test-account',
+            orgId: 'test-org',
+            projectId: 'test-project',
+          },
+        });
+
+        const actual = await tool.handler(
+          { flagIdentifier: 'user_dashboard_v2', environmentId: 'production' },
+          mockContext
+        );
+
+        expect(actual).toContain('"identifier": "user_dashboard_v2"');
+        expect(actual).toContain('"name": "User Dashboard V2"');
+        expect(actual).toContain('"envProperties"');
+        expect(actual).toContain('"version": 3');
+
+        server.close();
+      });
+    });
+
+    describe('when feature flag does not exist', () => {
+      it('returns error message', async () => {
+        server.use(
+          http.get(
+            'https://app.harness.io/gateway/cf/admin/features/nonexistent_flag',
+            () => {
+              return HttpResponse.json(
+                { error: 'Feature flag not found' },
+                { status: 404 }
+              );
+            }
+          )
+        );
+
+        server.listen();
+
+        const tool = HarnessConnectorConfig.tools.GET_FEATURE_FLAG as MCPToolDefinition;
+        const mockContext = createMockConnectorContext({
+          credentials: {
+            apiKey: 'test-api-key',
+            accountId: 'test-account',
+            orgId: 'test-org',
+            projectId: 'test-project',
+          },
+        });
+
+        const actual = await tool.handler(
+          { flagIdentifier: 'nonexistent_flag', environmentId: 'production' },
+          mockContext
+        );
+
+        expect(actual).toContain('Failed to get feature flag');
+        expect(actual).toContain('404');
+
+        server.close();
+      });
+    });
+  });
+
+  describe('.CREATE_FEATURE_FLAG', () => {
+    describe('when creation is successful', () => {
+      it('returns created feature flag', async () => {
+        const newFlag = {
+          identifier: 'mobile_dark_mode',
+          name: 'Mobile Dark Mode',
+          description: 'Dark mode toggle for mobile app',
+          kind: 'boolean',
+          permanent: false,
+          tags: ['mobile', 'ui'],
+          variations: [
+            {
+              identifier: 'enabled',
+              name: 'Dark Mode On',
+              value: true,
+              description: 'Dark mode is enabled',
+            },
+            {
+              identifier: 'disabled',
+              name: 'Dark Mode Off',
+              value: false,
+              description: 'Dark mode is disabled',
+            },
+          ],
+          defaultOnVariation: 'enabled',
+          defaultOffVariation: 'disabled',
+        };
+
+        const mockCreatedFlag = {
+          ...newFlag,
+          defaultServe: {
+            variation: 'disabled',
+          },
+          offVariation: 'disabled',
+          state: 'off',
+          createdAt: 1640995200000,
+          modifiedAt: 1640995200000,
+          version: 1,
+        };
+
+        server.use(
+          http.post('https://app.harness.io/gateway/cf/admin/features', () => {
+            return HttpResponse.json(mockCreatedFlag);
+          })
+        );
+
+        server.listen();
+
+        const tool = HarnessConnectorConfig.tools
+          .CREATE_FEATURE_FLAG as MCPToolDefinition;
+        const mockContext = createMockConnectorContext({
+          credentials: {
+            apiKey: 'test-api-key',
+            accountId: 'test-account',
+            orgId: 'test-org',
+            projectId: 'test-project',
+          },
+        });
+
+        const actual = await tool.handler(newFlag, mockContext);
+
+        expect(actual).toContain('"identifier": "mobile_dark_mode"');
+        expect(actual).toContain('"name": "Mobile Dark Mode"');
+        expect(actual).toContain('"kind": "boolean"');
+        expect(actual).toContain('"version": 1');
+
+        server.close();
+      });
+    });
+
+    describe('when creation fails due to validation', () => {
+      it('returns error message', async () => {
+        server.use(
+          http.post('https://app.harness.io/gateway/cf/admin/features', () => {
+            return HttpResponse.json(
+              { error: 'Invalid flag identifier', details: 'Identifier already exists' },
+              { status: 400 }
+            );
+          })
+        );
+
+        server.listen();
+
+        const tool = HarnessConnectorConfig.tools
+          .CREATE_FEATURE_FLAG as MCPToolDefinition;
+        const mockContext = createMockConnectorContext({
+          credentials: {
+            apiKey: 'test-api-key',
+            accountId: 'test-account',
+            orgId: 'test-org',
+            projectId: 'test-project',
+          },
+        });
+
+        const actual = await tool.handler(
+          {
+            identifier: 'existing_flag',
+            name: 'Existing Flag',
+            kind: 'boolean',
+            variations: [],
+            defaultOnVariation: 'on',
+            defaultOffVariation: 'off',
+          },
+          mockContext
+        );
+
+        expect(actual).toContain('Failed to create feature flag');
+        expect(actual).toContain('400');
+
+        server.close();
+      });
+    });
+  });
+
+  describe('.TOGGLE_FEATURE_FLAG', () => {
+    describe('when toggling to on', () => {
+      it('successfully enables the feature flag', async () => {
+        const mockUpdatedFlag = {
+          identifier: 'beta_features',
+          name: 'Beta Features Toggle',
+          state: 'on',
+          envProperties: {
+            environment: 'production',
+            state: 'on',
+            modifiedAt: 1640995200000,
+            version: 2,
+          },
+          version: 2,
+        };
+
+        server.use(
+          http.patch(
+            'https://app.harness.io/gateway/cf/admin/features/beta_features',
+            () => {
+              return HttpResponse.json(mockUpdatedFlag);
+            }
+          )
+        );
+
+        server.listen();
+
+        const tool = HarnessConnectorConfig.tools
+          .TOGGLE_FEATURE_FLAG as MCPToolDefinition;
+        const mockContext = createMockConnectorContext({
+          credentials: {
+            apiKey: 'test-api-key',
+            accountId: 'test-account',
+            orgId: 'test-org',
+            projectId: 'test-project',
+          },
+        });
+
+        const actual = await tool.handler(
+          { flagIdentifier: 'beta_features', environmentId: 'production', state: 'on' },
+          mockContext
+        );
+
+        expect(actual).toContain('"identifier": "beta_features"');
+        expect(actual).toContain('"state": "on"');
+        expect(actual).toContain('"version": 2');
+
+        server.close();
+      });
+    });
+
+    describe('when toggling to off', () => {
+      it('successfully disables the feature flag', async () => {
+        const mockUpdatedFlag = {
+          identifier: 'beta_features',
+          name: 'Beta Features Toggle',
+          state: 'off',
+          envProperties: {
+            environment: 'production',
+            state: 'off',
+            modifiedAt: 1640995200000,
+            version: 3,
+          },
+          version: 3,
+        };
+
+        server.use(
+          http.patch(
+            'https://app.harness.io/gateway/cf/admin/features/beta_features',
+            () => {
+              return HttpResponse.json(mockUpdatedFlag);
+            }
+          )
+        );
+
+        server.listen();
+
+        const tool = HarnessConnectorConfig.tools
+          .TOGGLE_FEATURE_FLAG as MCPToolDefinition;
+        const mockContext = createMockConnectorContext({
+          credentials: {
+            apiKey: 'test-api-key',
+            accountId: 'test-account',
+            orgId: 'test-org',
+            projectId: 'test-project',
+          },
+        });
+
+        const actual = await tool.handler(
+          { flagIdentifier: 'beta_features', environmentId: 'production', state: 'off' },
+          mockContext
+        );
+
+        expect(actual).toContain('"state": "off"');
+        expect(actual).toContain('"version": 3');
+
+        server.close();
+      });
+    });
+  });
+
+  describe('.UPDATE_FEATURE_FLAG', () => {
+    describe('when update is successful', () => {
+      it('returns updated feature flag with custom instructions', async () => {
+        const mockUpdatedFlag = {
+          identifier: 'user_dashboard_v2',
+          name: 'User Dashboard V2',
+          defaultServe: {
+            variation: 'true',
+          },
+          version: 4,
+        };
+
+        server.use(
+          http.patch(
+            'https://app.harness.io/gateway/cf/admin/features/user_dashboard_v2',
+            () => {
+              return HttpResponse.json(mockUpdatedFlag);
+            }
+          )
+        );
+
+        server.listen();
+
+        const tool = HarnessConnectorConfig.tools
+          .UPDATE_FEATURE_FLAG as MCPToolDefinition;
+        const mockContext = createMockConnectorContext({
+          credentials: {
+            apiKey: 'test-api-key',
+            accountId: 'test-account',
+            orgId: 'test-org',
+            projectId: 'test-project',
+          },
+        });
+
+        const actual = await tool.handler(
+          {
+            flagIdentifier: 'user_dashboard_v2',
+            environmentId: 'production',
+            instructions: [
+              {
+                kind: 'updateDefaultServe',
+                parameters: {
+                  variation: 'true',
+                },
+              },
+            ],
+          },
+          mockContext
+        );
+
+        expect(actual).toContain('"identifier": "user_dashboard_v2"');
+        expect(actual).toContain('"version": 4');
+
+        server.close();
+      });
+    });
+
+    describe('when update fails', () => {
+      it('returns error message', async () => {
+        server.use(
+          http.patch(
+            'https://app.harness.io/gateway/cf/admin/features/invalid_flag',
+            () => {
+              return HttpResponse.json({ error: 'Invalid instruction' }, { status: 400 });
+            }
+          )
+        );
+
+        server.listen();
+
+        const tool = HarnessConnectorConfig.tools
+          .UPDATE_FEATURE_FLAG as MCPToolDefinition;
+        const mockContext = createMockConnectorContext({
+          credentials: {
+            apiKey: 'test-api-key',
+            accountId: 'test-account',
+            orgId: 'test-org',
+            projectId: 'test-project',
+          },
+        });
+
+        const actual = await tool.handler(
+          {
+            flagIdentifier: 'invalid_flag',
+            environmentId: 'production',
+            instructions: [{ kind: 'invalidInstruction' }],
+          },
+          mockContext
+        );
+
+        expect(actual).toContain('Failed to update feature flag');
+        expect(actual).toContain('400');
+
+        server.close();
+      });
+    });
+  });
+
+  describe('.DELETE_FEATURE_FLAG', () => {
+    describe('when deletion is successful', () => {
+      it('returns success message', async () => {
+        server.use(
+          http.delete(
+            'https://app.harness.io/gateway/cf/admin/features/old_feature',
+            () => {
+              return HttpResponse.json({}, { status: 204 });
+            }
+          )
+        );
+
+        server.listen();
+
+        const tool = HarnessConnectorConfig.tools
+          .DELETE_FEATURE_FLAG as MCPToolDefinition;
+        const mockContext = createMockConnectorContext({
+          credentials: {
+            apiKey: 'test-api-key',
+            accountId: 'test-account',
+            orgId: 'test-org',
+            projectId: 'test-project',
+          },
+        });
+
+        const actual = await tool.handler({ flagIdentifier: 'old_feature' }, mockContext);
+
+        expect(actual).toContain('Feature flag old_feature deleted successfully');
+
+        server.close();
+      });
+    });
+
+    describe('when flag does not exist', () => {
+      it('returns error message', async () => {
+        server.use(
+          http.delete(
+            'https://app.harness.io/gateway/cf/admin/features/nonexistent_flag',
+            () => {
+              return HttpResponse.json(
+                { error: 'Feature flag not found' },
+                { status: 404 }
+              );
+            }
+          )
+        );
+
+        server.listen();
+
+        const tool = HarnessConnectorConfig.tools
+          .DELETE_FEATURE_FLAG as MCPToolDefinition;
+        const mockContext = createMockConnectorContext({
+          credentials: {
+            apiKey: 'test-api-key',
+            accountId: 'test-account',
+            orgId: 'test-org',
+            projectId: 'test-project',
+          },
+        });
+
+        const actual = await tool.handler(
+          { flagIdentifier: 'nonexistent_flag' },
+          mockContext
+        );
+
+        expect(actual).toContain('Failed to delete feature flag');
+        expect(actual).toContain('404');
+
+        server.close();
+      });
+    });
+  });
+
+  describe('.GET_TARGETS', () => {
+    describe('when request is successful', () => {
+      it('returns targets list', async () => {
+        const mockTargets = {
+          targets: [
+            {
+              identifier: 'user_123',
+              account: 'test-account',
+              org: 'test-org',
+              environment: 'production',
+              project: 'test-project',
+              name: 'John Doe',
+              anonymous: false,
+              attributes: {
+                email: 'john@example.com',
+                plan: 'premium',
+                region: 'us-east-1',
+              },
+              createdAt: 1640995200000,
+            },
+          ],
+        };
+
+        server.use(
+          http.get('https://app.harness.io/gateway/cf/admin/targets', () => {
+            return HttpResponse.json(mockTargets);
+          })
+        );
+
+        server.listen();
+
+        const tool = HarnessConnectorConfig.tools.GET_TARGETS as MCPToolDefinition;
+        const mockContext = createMockConnectorContext({
+          credentials: {
+            apiKey: 'test-api-key',
+            accountId: 'test-account',
+            orgId: 'test-org',
+            projectId: 'test-project',
+          },
+        });
+
+        const actual = await tool.handler({ environmentId: 'production' }, mockContext);
+
+        expect(actual).toContain('"identifier": "user_123"');
+        expect(actual).toContain('"name": "John Doe"');
+        expect(actual).toContain('"email": "john@example.com"');
+        expect(actual).toContain('"plan": "premium"');
+
+        server.close();
+      });
+    });
+
+    describe('when API returns empty results', () => {
+      it('returns empty targets array', async () => {
+        const mockTargets = {
+          targets: [],
+        };
+
+        server.use(
+          http.get('https://app.harness.io/gateway/cf/admin/targets', () => {
+            return HttpResponse.json(mockTargets);
+          })
+        );
+
+        server.listen();
+
+        const tool = HarnessConnectorConfig.tools.GET_TARGETS as MCPToolDefinition;
+        const mockContext = createMockConnectorContext({
+          credentials: {
+            apiKey: 'test-api-key',
+            accountId: 'test-account',
+            orgId: 'test-org',
+            projectId: 'test-project',
+          },
+        });
+
+        const actual = await tool.handler({ environmentId: 'production' }, mockContext);
+
+        expect(actual).toContain('"targets": []');
+
+        server.close();
+      });
+    });
+  });
+
+  describe('.GET_TARGET_GROUPS', () => {
+    describe('when request is successful', () => {
+      it('returns target groups list', async () => {
+        const mockTargetGroups = {
+          targetGroups: [
+            {
+              identifier: 'premium_users',
+              name: 'Premium Users',
+              environment: 'production',
+              project: 'test-project',
+              account: 'test-account',
+              org: 'test-org',
+              description: 'Users with premium subscriptions',
+              tags: ['premium', 'subscription'],
+              rules: [
+                {
+                  attribute: 'plan',
+                  op: 'equal',
+                  values: ['premium', 'enterprise'],
+                },
+              ],
+              createdAt: 1640995200000,
+              modifiedAt: 1640995200000,
+              version: 1,
+            },
+          ],
+        };
+
+        server.use(
+          http.get('https://app.harness.io/gateway/cf/admin/target-groups', () => {
+            return HttpResponse.json(mockTargetGroups);
+          })
+        );
+
+        server.listen();
+
+        const tool = HarnessConnectorConfig.tools.GET_TARGET_GROUPS as MCPToolDefinition;
+        const mockContext = createMockConnectorContext({
+          credentials: {
+            apiKey: 'test-api-key',
+            accountId: 'test-account',
+            orgId: 'test-org',
+            projectId: 'test-project',
+          },
+        });
+
+        const actual = await tool.handler({ environmentId: 'production' }, mockContext);
+
+        expect(actual).toContain('"identifier": "premium_users"');
+        expect(actual).toContain('"name": "Premium Users"');
+        expect(actual).toContain('"description": "Users with premium subscriptions"');
+        expect(actual).toContain('"rules"');
+
+        server.close();
+      });
+    });
+  });
+
+  describe('.GET_FEATURE_FLAG_METRICS', () => {
+    describe('when request is successful', () => {
+      it('returns feature flag metrics and analytics', async () => {
+        const mockMetrics = {
+          flagIdentifier: 'user_dashboard_v2',
+          environment: 'production',
+          variationMetrics: [
+            {
+              variation: 'true',
+              count: 15420,
+              percentage: 23.5,
+            },
+            {
+              variation: 'false',
+              count: 50180,
+              percentage: 76.5,
+            },
+          ],
+          totalEvaluations: 65600,
+        };
+
+        server.use(
+          http.get(
+            'https://app.harness.io/gateway/cf/admin/metrics/flags/user_dashboard_v2',
+            () => {
+              return HttpResponse.json(mockMetrics);
+            }
+          )
+        );
+
+        server.listen();
+
+        const tool = HarnessConnectorConfig.tools
+          .GET_FEATURE_FLAG_METRICS as MCPToolDefinition;
+        const mockContext = createMockConnectorContext({
+          credentials: {
+            apiKey: 'test-api-key',
+            accountId: 'test-account',
+            orgId: 'test-org',
+            projectId: 'test-project',
+          },
+        });
+
+        const actual = await tool.handler(
+          {
+            flagIdentifier: 'user_dashboard_v2',
+            environmentId: 'production',
+            fromTimestamp: 1640995200000,
+            toTimestamp: 1641081600000,
+          },
+          mockContext
+        );
+
+        expect(actual).toContain('"flagIdentifier": "user_dashboard_v2"');
+        expect(actual).toContain('"totalEvaluations": 65600');
+        expect(actual).toContain('"variationMetrics"');
+        expect(actual).toContain('"percentage": 23.5');
+
+        server.close();
+      });
+    });
+
+    describe('when flag has no metrics', () => {
+      it('returns empty metrics', async () => {
+        const mockMetrics = {
+          flagIdentifier: 'new_feature',
+          environment: 'production',
+          variationMetrics: [],
+          totalEvaluations: 0,
+        };
+
+        server.use(
+          http.get(
+            'https://app.harness.io/gateway/cf/admin/metrics/flags/new_feature',
+            () => {
+              return HttpResponse.json(mockMetrics);
+            }
+          )
+        );
+
+        server.listen();
+
+        const tool = HarnessConnectorConfig.tools
+          .GET_FEATURE_FLAG_METRICS as MCPToolDefinition;
+        const mockContext = createMockConnectorContext({
+          credentials: {
+            apiKey: 'test-api-key',
+            accountId: 'test-account',
+            orgId: 'test-org',
+            projectId: 'test-project',
+          },
+        });
+
+        const actual = await tool.handler(
+          { flagIdentifier: 'new_feature', environmentId: 'production' },
+          mockContext
+        );
+
+        expect(actual).toContain('"totalEvaluations": 0');
+        expect(actual).toContain('"variationMetrics": []');
+
+        server.close();
+      });
+    });
+  });
+});

--- a/packages/mcp-connectors/src/connectors/harness.ts
+++ b/packages/mcp-connectors/src/connectors/harness.ts
@@ -1,0 +1,526 @@
+import { mcpConnectorConfig } from '@stackone/mcp-config-types';
+import { z } from 'zod';
+
+interface HarnessFeatureFlag {
+  identifier: string;
+  name: string;
+  description?: string;
+  kind: 'boolean' | 'int' | 'string' | 'json';
+  permanent: boolean;
+  tags?: string[];
+  defaultServe: {
+    variation: string;
+  };
+  offVariation: string;
+  variations: Array<{
+    identifier: string;
+    name: string;
+    value: string | boolean | number | object;
+    description?: string;
+  }>;
+  prerequisites?: Array<{
+    flag: string;
+    variations: string[];
+  }>;
+  state: 'on' | 'off';
+  envProperties?: {
+    environment: string;
+    state: 'on' | 'off';
+    defaultServe: {
+      variation: string;
+    };
+    offVariation: string;
+    modifiedAt: number;
+    version: number;
+  };
+  createdAt: number;
+  modifiedAt: number;
+  version: number;
+  [key: string]: unknown;
+}
+
+interface HarnessTarget {
+  identifier: string;
+  account: string;
+  org: string;
+  environment: string;
+  project: string;
+  name: string;
+  anonymous?: boolean;
+  attributes?: Record<string, string>;
+  createdAt?: number;
+  segments?: Array<{
+    identifier: string;
+    name: string;
+  }>;
+  [key: string]: unknown;
+}
+
+interface HarnessTargetGroup {
+  identifier: string;
+  name: string;
+  environment: string;
+  project: string;
+  account: string;
+  org: string;
+  description?: string;
+  tags?: string[];
+  includedTargets?: Array<{
+    identifier: string;
+    name: string;
+  }>;
+  excludedTargets?: Array<{
+    identifier: string;
+    name: string;
+  }>;
+  rules?: Array<{
+    attribute: string;
+    op: string;
+    values: string[];
+  }>;
+  createdAt: number;
+  modifiedAt: number;
+  version: number;
+  [key: string]: unknown;
+}
+
+interface HarnessMetrics {
+  flagIdentifier: string;
+  environment: string;
+  variationMetrics: Array<{
+    variation: string;
+    count: number;
+    percentage: number;
+  }>;
+  totalEvaluations: number;
+  [key: string]: unknown;
+}
+
+class HarnessClient {
+  private baseUrl: string;
+  private headers: {
+    Authorization: string;
+    'Content-Type': string;
+    'Harness-Account': string;
+  };
+  private accountId: string;
+  private orgId: string;
+  private projectId: string;
+
+  constructor(apiKey: string, accountId: string, orgId: string, projectId: string) {
+    this.baseUrl = 'https://app.harness.io/gateway/cf/admin';
+    this.accountId = accountId;
+    this.orgId = orgId;
+    this.projectId = projectId;
+    this.headers = {
+      Authorization: `Bearer ${apiKey}`,
+      'Content-Type': 'application/json',
+      'Harness-Account': accountId,
+    };
+  }
+
+  private async makeRequest(
+    endpoint: string,
+    method: 'GET' | 'POST' | 'PUT' | 'PATCH' | 'DELETE' = 'GET',
+    body?: unknown
+  ): Promise<unknown> {
+    const url = `${this.baseUrl}${endpoint}`;
+    const options: RequestInit = {
+      method,
+      headers: this.headers,
+    };
+
+    if (body && (method === 'POST' || method === 'PUT' || method === 'PATCH')) {
+      options.body = JSON.stringify(body);
+    }
+
+    const response = await fetch(url, options);
+
+    if (!response.ok) {
+      throw new Error(`Harness API error: ${response.status} ${response.statusText}`);
+    }
+
+    return response.json();
+  }
+
+  async getFeatureFlags(
+    environmentId: string
+  ): Promise<{ features: HarnessFeatureFlag[] }> {
+    const endpoint = `/features?accountIdentifier=${this.accountId}&orgIdentifier=${this.orgId}&projectIdentifier=${this.projectId}&environmentIdentifier=${environmentId}`;
+    return (await this.makeRequest(endpoint)) as { features: HarnessFeatureFlag[] };
+  }
+
+  async getFeatureFlag(
+    flagIdentifier: string,
+    environmentId: string
+  ): Promise<HarnessFeatureFlag> {
+    const endpoint = `/features/${flagIdentifier}?accountIdentifier=${this.accountId}&orgIdentifier=${this.orgId}&projectIdentifier=${this.projectId}&environmentIdentifier=${environmentId}`;
+    return (await this.makeRequest(endpoint)) as HarnessFeatureFlag;
+  }
+
+  async createFeatureFlag(flagData: {
+    identifier: string;
+    name: string;
+    description?: string;
+    kind: 'boolean' | 'int' | 'string' | 'json';
+    permanent?: boolean;
+    tags?: string[];
+    variations: Array<{
+      identifier: string;
+      name: string;
+      value: string | boolean | number | object;
+      description?: string;
+    }>;
+    defaultOnVariation: string;
+    defaultOffVariation: string;
+  }): Promise<HarnessFeatureFlag> {
+    const endpoint = `/features?accountIdentifier=${this.accountId}&orgIdentifier=${this.orgId}&projectIdentifier=${this.projectId}`;
+    return (await this.makeRequest(endpoint, 'POST', flagData)) as HarnessFeatureFlag;
+  }
+
+  async updateFeatureFlag(
+    flagIdentifier: string,
+    environmentId: string,
+    instructions: Array<{
+      kind: string;
+      parameters?: Record<string, unknown>;
+    }>
+  ): Promise<HarnessFeatureFlag> {
+    const endpoint = `/features/${flagIdentifier}?accountIdentifier=${this.accountId}&orgIdentifier=${this.orgId}&projectIdentifier=${this.projectId}&environmentIdentifier=${environmentId}`;
+    return (await this.makeRequest(endpoint, 'PATCH', {
+      instructions,
+    })) as HarnessFeatureFlag;
+  }
+
+  async toggleFeatureFlag(
+    flagIdentifier: string,
+    environmentId: string,
+    state: 'on' | 'off'
+  ): Promise<HarnessFeatureFlag> {
+    const instruction = {
+      kind: state === 'on' ? 'setFeatureFlagState' : 'setFeatureFlagState',
+      parameters: {
+        state,
+      },
+    };
+    return this.updateFeatureFlag(flagIdentifier, environmentId, [instruction]);
+  }
+
+  async deleteFeatureFlag(flagIdentifier: string): Promise<void> {
+    const endpoint = `/features/${flagIdentifier}?accountIdentifier=${this.accountId}&orgIdentifier=${this.orgId}&projectIdentifier=${this.projectId}`;
+    const response = await fetch(`${this.baseUrl}${endpoint}`, {
+      method: 'DELETE',
+      headers: this.headers,
+    });
+
+    if (!response.ok) {
+      throw new Error(`Harness API error: ${response.status} ${response.statusText}`);
+    }
+  }
+
+  async getTargets(environmentId: string): Promise<{ targets: HarnessTarget[] }> {
+    const endpoint = `/targets?accountIdentifier=${this.accountId}&orgIdentifier=${this.orgId}&projectIdentifier=${this.projectId}&environmentIdentifier=${environmentId}`;
+    return (await this.makeRequest(endpoint)) as { targets: HarnessTarget[] };
+  }
+
+  async getTargetGroups(
+    environmentId: string
+  ): Promise<{ targetGroups: HarnessTargetGroup[] }> {
+    const endpoint = `/target-groups?accountIdentifier=${this.accountId}&orgIdentifier=${this.orgId}&projectIdentifier=${this.projectId}&environmentIdentifier=${environmentId}`;
+    return (await this.makeRequest(endpoint)) as { targetGroups: HarnessTargetGroup[] };
+  }
+
+  async getFeatureFlagMetrics(
+    flagIdentifier: string,
+    environmentId: string,
+    fromTimestamp?: number,
+    toTimestamp?: number
+  ): Promise<HarnessMetrics> {
+    let endpoint = `/metrics/flags/${flagIdentifier}?accountIdentifier=${this.accountId}&orgIdentifier=${this.orgId}&projectIdentifier=${this.projectId}&environmentIdentifier=${environmentId}`;
+
+    if (fromTimestamp) {
+      endpoint += `&from=${fromTimestamp}`;
+    }
+    if (toTimestamp) {
+      endpoint += `&to=${toTimestamp}`;
+    }
+
+    return (await this.makeRequest(endpoint)) as HarnessMetrics;
+  }
+}
+
+export const HarnessConnectorConfig = mcpConnectorConfig({
+  name: 'Harness',
+  key: 'harness',
+  version: '1.0.0',
+  logo: 'https://stackone-logos.com/api/harness/filled/svg',
+  credentials: z.object({
+    apiKey: z
+      .string()
+      .describe(
+        'Harness API Key from Personal Access Tokens :: har_platform_1234567890abcdef :: https://developer.harness.io/docs/platform/automation/api/add-and-manage-api-keys/'
+      ),
+    accountId: z
+      .string()
+      .describe(
+        'Harness Account Identifier :: wlgELJ0TTre5aZhzpt8gVA :: Found in Account Settings'
+      ),
+    orgId: z
+      .string()
+      .describe(
+        'Harness Organization Identifier :: default :: Found in Organization Settings'
+      ),
+    projectId: z
+      .string()
+      .describe(
+        'Harness Project Identifier :: default_project :: Found in Project Settings'
+      ),
+  }),
+  setup: z.object({}),
+  examplePrompt:
+    'Get all feature flags in the production environment, toggle the beta_features flag to on, check the usage metrics for user_dashboard_v2 flag, and create a new feature flag for the mobile app.',
+  tools: (tool) => ({
+    GET_FEATURE_FLAGS: tool({
+      name: 'harness_get_feature_flags',
+      description: 'Get all feature flags for a specific environment',
+      schema: z.object({
+        environmentId: z
+          .string()
+          .describe('Environment identifier (e.g., production, staging, dev)'),
+      }),
+      handler: async (args, context) => {
+        try {
+          const { apiKey, accountId, orgId, projectId } = await context.getCredentials();
+          const client = new HarnessClient(apiKey, accountId, orgId, projectId);
+          const result = await client.getFeatureFlags(args.environmentId);
+          return JSON.stringify(result, null, 2);
+        } catch (error) {
+          return `Failed to get feature flags: ${error instanceof Error ? error.message : String(error)}`;
+        }
+      },
+    }),
+
+    GET_FEATURE_FLAG: tool({
+      name: 'harness_get_feature_flag',
+      description: 'Get detailed information about a specific feature flag',
+      schema: z.object({
+        flagIdentifier: z.string().describe('Feature flag identifier'),
+        environmentId: z
+          .string()
+          .describe('Environment identifier (e.g., production, staging, dev)'),
+      }),
+      handler: async (args, context) => {
+        try {
+          const { apiKey, accountId, orgId, projectId } = await context.getCredentials();
+          const client = new HarnessClient(apiKey, accountId, orgId, projectId);
+          const result = await client.getFeatureFlag(
+            args.flagIdentifier,
+            args.environmentId
+          );
+          return JSON.stringify(result, null, 2);
+        } catch (error) {
+          return `Failed to get feature flag: ${error instanceof Error ? error.message : String(error)}`;
+        }
+      },
+    }),
+
+    CREATE_FEATURE_FLAG: tool({
+      name: 'harness_create_feature_flag',
+      description: 'Create a new feature flag',
+      schema: z.object({
+        identifier: z.string().describe('Unique feature flag identifier'),
+        name: z.string().describe('Human-readable feature flag name'),
+        description: z.string().optional().describe('Feature flag description'),
+        kind: z
+          .enum(['boolean', 'int', 'string', 'json'])
+          .describe('Type of feature flag'),
+        permanent: z.boolean().optional().describe('Whether the flag is permanent'),
+        tags: z.array(z.string()).optional().describe('Tags for organizing flags'),
+        variations: z
+          .array(
+            z.object({
+              identifier: z.string().describe('Variation identifier'),
+              name: z.string().describe('Variation name'),
+              value: z
+                .union([z.string(), z.boolean(), z.number(), z.object({})])
+                .describe('Variation value'),
+              description: z.string().optional().describe('Variation description'),
+            })
+          )
+          .describe('Available variations for the flag'),
+        defaultOnVariation: z.string().describe('Default variation when flag is on'),
+        defaultOffVariation: z.string().describe('Default variation when flag is off'),
+      }),
+      handler: async (args, context) => {
+        try {
+          const { apiKey, accountId, orgId, projectId } = await context.getCredentials();
+          const client = new HarnessClient(apiKey, accountId, orgId, projectId);
+          const result = await client.createFeatureFlag(args);
+          return JSON.stringify(result, null, 2);
+        } catch (error) {
+          return `Failed to create feature flag: ${error instanceof Error ? error.message : String(error)}`;
+        }
+      },
+    }),
+
+    TOGGLE_FEATURE_FLAG: tool({
+      name: 'harness_toggle_feature_flag',
+      description: 'Turn a feature flag on or off in a specific environment',
+      schema: z.object({
+        flagIdentifier: z.string().describe('Feature flag identifier'),
+        environmentId: z
+          .string()
+          .describe('Environment identifier (e.g., production, staging, dev)'),
+        state: z.enum(['on', 'off']).describe('New state for the feature flag'),
+      }),
+      handler: async (args, context) => {
+        try {
+          const { apiKey, accountId, orgId, projectId } = await context.getCredentials();
+          const client = new HarnessClient(apiKey, accountId, orgId, projectId);
+          const result = await client.toggleFeatureFlag(
+            args.flagIdentifier,
+            args.environmentId,
+            args.state
+          );
+          return JSON.stringify(result, null, 2);
+        } catch (error) {
+          return `Failed to toggle feature flag: ${error instanceof Error ? error.message : String(error)}`;
+        }
+      },
+    }),
+
+    UPDATE_FEATURE_FLAG: tool({
+      name: 'harness_update_feature_flag',
+      description: 'Update a feature flag with custom instructions',
+      schema: z.object({
+        flagIdentifier: z.string().describe('Feature flag identifier'),
+        environmentId: z
+          .string()
+          .describe('Environment identifier (e.g., production, staging, dev)'),
+        instructions: z
+          .array(
+            z.object({
+              kind: z
+                .string()
+                .describe(
+                  'Type of instruction (e.g., setFeatureFlagState, updateDefaultServe)'
+                ),
+              parameters: z
+                .record(z.unknown())
+                .optional()
+                .describe('Parameters for the instruction'),
+            })
+          )
+          .describe('Array of update instructions'),
+      }),
+      handler: async (args, context) => {
+        try {
+          const { apiKey, accountId, orgId, projectId } = await context.getCredentials();
+          const client = new HarnessClient(apiKey, accountId, orgId, projectId);
+          const result = await client.updateFeatureFlag(
+            args.flagIdentifier,
+            args.environmentId,
+            args.instructions
+          );
+          return JSON.stringify(result, null, 2);
+        } catch (error) {
+          return `Failed to update feature flag: ${error instanceof Error ? error.message : String(error)}`;
+        }
+      },
+    }),
+
+    DELETE_FEATURE_FLAG: tool({
+      name: 'harness_delete_feature_flag',
+      description: 'Delete a feature flag (use with caution)',
+      schema: z.object({
+        flagIdentifier: z.string().describe('Feature flag identifier to delete'),
+      }),
+      handler: async (args, context) => {
+        try {
+          const { apiKey, accountId, orgId, projectId } = await context.getCredentials();
+          const client = new HarnessClient(apiKey, accountId, orgId, projectId);
+          await client.deleteFeatureFlag(args.flagIdentifier);
+          return `Feature flag ${args.flagIdentifier} deleted successfully`;
+        } catch (error) {
+          return `Failed to delete feature flag: ${error instanceof Error ? error.message : String(error)}`;
+        }
+      },
+    }),
+
+    GET_TARGETS: tool({
+      name: 'harness_get_targets',
+      description:
+        'Get all targets (users/entities) for feature flag evaluation in an environment',
+      schema: z.object({
+        environmentId: z
+          .string()
+          .describe('Environment identifier (e.g., production, staging, dev)'),
+      }),
+      handler: async (args, context) => {
+        try {
+          const { apiKey, accountId, orgId, projectId } = await context.getCredentials();
+          const client = new HarnessClient(apiKey, accountId, orgId, projectId);
+          const result = await client.getTargets(args.environmentId);
+          return JSON.stringify(result, null, 2);
+        } catch (error) {
+          return `Failed to get targets: ${error instanceof Error ? error.message : String(error)}`;
+        }
+      },
+    }),
+
+    GET_TARGET_GROUPS: tool({
+      name: 'harness_get_target_groups',
+      description:
+        'Get all target groups (segments) for feature flag targeting in an environment',
+      schema: z.object({
+        environmentId: z
+          .string()
+          .describe('Environment identifier (e.g., production, staging, dev)'),
+      }),
+      handler: async (args, context) => {
+        try {
+          const { apiKey, accountId, orgId, projectId } = await context.getCredentials();
+          const client = new HarnessClient(apiKey, accountId, orgId, projectId);
+          const result = await client.getTargetGroups(args.environmentId);
+          return JSON.stringify(result, null, 2);
+        } catch (error) {
+          return `Failed to get target groups: ${error instanceof Error ? error.message : String(error)}`;
+        }
+      },
+    }),
+
+    GET_FEATURE_FLAG_METRICS: tool({
+      name: 'harness_get_feature_flag_metrics',
+      description: 'Get usage metrics and analytics for a specific feature flag',
+      schema: z.object({
+        flagIdentifier: z.string().describe('Feature flag identifier'),
+        environmentId: z
+          .string()
+          .describe('Environment identifier (e.g., production, staging, dev)'),
+        fromTimestamp: z
+          .number()
+          .optional()
+          .describe('Start timestamp for metrics (Unix timestamp in milliseconds)'),
+        toTimestamp: z
+          .number()
+          .optional()
+          .describe('End timestamp for metrics (Unix timestamp in milliseconds)'),
+      }),
+      handler: async (args, context) => {
+        try {
+          const { apiKey, accountId, orgId, projectId } = await context.getCredentials();
+          const client = new HarnessClient(apiKey, accountId, orgId, projectId);
+          const result = await client.getFeatureFlagMetrics(
+            args.flagIdentifier,
+            args.environmentId,
+            args.fromTimestamp,
+            args.toTimestamp
+          );
+          return JSON.stringify(result, null, 2);
+        } catch (error) {
+          return `Failed to get feature flag metrics: ${error instanceof Error ? error.message : String(error)}`;
+        }
+      },
+    }),
+  }),
+});

--- a/packages/mcp-connectors/src/connectors/luma.spec.ts
+++ b/packages/mcp-connectors/src/connectors/luma.spec.ts
@@ -192,10 +192,7 @@ describe('#LumaConnector', () => {
       it('returns error message', async () => {
         server.use(
           http.post('https://public-api.luma.com/v1/event/create', () => {
-            return HttpResponse.json(
-              { error: 'Invalid calendar ID' },
-              { status: 400 }
-            );
+            return HttpResponse.json({ error: 'Invalid calendar ID' }, { status: 400 });
           })
         );
 
@@ -602,10 +599,7 @@ describe('#LumaConnector', () => {
       it('returns error message', async () => {
         server.use(
           http.post('https://public-api.luma.com/v1/event/add-guests', () => {
-            return HttpResponse.json(
-              { error: 'Event is at capacity' },
-              { status: 400 }
-            );
+            return HttpResponse.json({ error: 'Event is at capacity' }, { status: 400 });
           })
         );
 
@@ -664,8 +658,7 @@ describe('#LumaConnector', () => {
 
         server.listen();
 
-        const tool = LumaConnectorConfig.tools
-          .LIST_CALENDAR_EVENTS as MCPToolDefinition;
+        const tool = LumaConnectorConfig.tools.LIST_CALENDAR_EVENTS as MCPToolDefinition;
         const mockContext = createMockConnectorContext({
           credentials: {
             apiKey: 'test-api-key',
@@ -706,8 +699,7 @@ describe('#LumaConnector', () => {
 
         server.listen();
 
-        const tool = LumaConnectorConfig.tools
-          .LIST_CALENDAR_EVENTS as MCPToolDefinition;
+        const tool = LumaConnectorConfig.tools.LIST_CALENDAR_EVENTS as MCPToolDefinition;
         const mockContext = createMockConnectorContext({
           credentials: {
             apiKey: 'test-api-key',
@@ -754,8 +746,7 @@ describe('#LumaConnector', () => {
 
         server.listen();
 
-        const tool = LumaConnectorConfig.tools
-          .LIST_CALENDAR_EVENTS as MCPToolDefinition;
+        const tool = LumaConnectorConfig.tools.LIST_CALENDAR_EVENTS as MCPToolDefinition;
         const mockContext = createMockConnectorContext({
           credentials: {
             apiKey: 'test-api-key',
@@ -784,8 +775,7 @@ describe('#LumaConnector', () => {
 
         server.listen();
 
-        const tool = LumaConnectorConfig.tools
-          .LIST_CALENDAR_EVENTS as MCPToolDefinition;
+        const tool = LumaConnectorConfig.tools.LIST_CALENDAR_EVENTS as MCPToolDefinition;
         const mockContext = createMockConnectorContext({
           credentials: {
             apiKey: 'test-api-key',

--- a/packages/mcp-connectors/src/connectors/luma.spec.ts
+++ b/packages/mcp-connectors/src/connectors/luma.spec.ts
@@ -1,0 +1,804 @@
+import type { MCPToolDefinition } from '@stackone/mcp-config-types';
+import { http, HttpResponse } from 'msw';
+import { setupServer } from 'msw/node';
+import { describe, expect, it } from 'vitest';
+import { createMockConnectorContext } from '../__mocks__/context';
+import { LumaConnectorConfig } from './luma';
+
+const server = setupServer();
+
+describe('#LumaConnector', () => {
+  describe('.GET_SELF', () => {
+    describe('when request is successful', () => {
+      it('returns authenticated user information', async () => {
+        const mockUser = {
+          api_id: 'usr-abc123',
+          name: 'John Doe',
+          username: 'johndoe',
+          email: 'john@example.com',
+          avatar_url: 'https://example.com/avatar.jpg',
+        };
+
+        server.use(
+          http.get('https://public-api.luma.com/v1/user/get-self', () => {
+            return HttpResponse.json(mockUser);
+          })
+        );
+
+        server.listen();
+
+        const tool = LumaConnectorConfig.tools.GET_SELF as MCPToolDefinition;
+        const mockContext = createMockConnectorContext({
+          credentials: {
+            apiKey: 'test-api-key',
+          },
+        });
+
+        const actual = await tool.handler({}, mockContext);
+
+        expect(actual).toContain('"api_id": "usr-abc123"');
+        expect(actual).toContain('"name": "John Doe"');
+        expect(actual).toContain('"email": "john@example.com"');
+
+        server.close();
+      });
+    });
+
+    describe('when API returns error', () => {
+      it('returns error message', async () => {
+        server.use(
+          http.get('https://public-api.luma.com/v1/user/get-self', () => {
+            return HttpResponse.json({ error: 'Unauthorized' }, { status: 401 });
+          })
+        );
+
+        server.listen();
+
+        const tool = LumaConnectorConfig.tools.GET_SELF as MCPToolDefinition;
+        const mockContext = createMockConnectorContext({
+          credentials: {
+            apiKey: 'invalid-key',
+          },
+        });
+
+        const actual = await tool.handler({}, mockContext);
+
+        expect(actual).toContain('Failed to get user info');
+        expect(actual).toContain('401');
+
+        server.close();
+      });
+    });
+  });
+
+  describe('.GET_EVENT', () => {
+    describe('when event exists', () => {
+      it('returns detailed event information', async () => {
+        const mockEvent = {
+          api_id: 'evt-xyz789',
+          name: 'Tech Conference 2024',
+          description: 'Annual tech conference',
+          start_at: '2024-06-15T09:00:00Z',
+          end_at: '2024-06-15T17:00:00Z',
+          timezone: 'America/New_York',
+          url: 'https://lu.ma/tech-conf-2024',
+          cover_url: 'https://example.com/cover.jpg',
+          visibility: 'public',
+          capacity: 500,
+          location: {
+            type: 'venue',
+            address: '123 Conference Center Dr, San Francisco, CA',
+          },
+        };
+
+        server.use(
+          http.get('https://public-api.luma.com/v1/event/get', () => {
+            return HttpResponse.json(mockEvent);
+          })
+        );
+
+        server.listen();
+
+        const tool = LumaConnectorConfig.tools.GET_EVENT as MCPToolDefinition;
+        const mockContext = createMockConnectorContext({
+          credentials: {
+            apiKey: 'test-api-key',
+          },
+        });
+
+        const actual = await tool.handler({ eventId: 'evt-xyz789' }, mockContext);
+
+        expect(actual).toContain('"api_id": "evt-xyz789"');
+        expect(actual).toContain('"name": "Tech Conference 2024"');
+        expect(actual).toContain('"capacity": 500');
+
+        server.close();
+      });
+    });
+
+    describe('when event does not exist', () => {
+      it('returns error message', async () => {
+        server.use(
+          http.get('https://public-api.luma.com/v1/event/get', () => {
+            return HttpResponse.json({ error: 'Event not found' }, { status: 404 });
+          })
+        );
+
+        server.listen();
+
+        const tool = LumaConnectorConfig.tools.GET_EVENT as MCPToolDefinition;
+        const mockContext = createMockConnectorContext({
+          credentials: {
+            apiKey: 'test-api-key',
+          },
+        });
+
+        const actual = await tool.handler({ eventId: 'nonexistent' }, mockContext);
+
+        expect(actual).toContain('Failed to get event');
+        expect(actual).toContain('404');
+
+        server.close();
+      });
+    });
+  });
+
+  describe('.CREATE_EVENT', () => {
+    describe('when creation is successful', () => {
+      it('returns created event', async () => {
+        const newEvent = {
+          name: 'Product Launch',
+          start_at: '2024-07-20T18:00:00Z',
+          calendar_api_id: 'cal-123',
+          description: 'Exciting new product reveal',
+          end_at: '2024-07-20T20:00:00Z',
+          timezone: 'America/Los_Angeles',
+          visibility: 'public',
+          capacity: 100,
+        };
+
+        const mockCreatedEvent = {
+          ...newEvent,
+          api_id: 'evt-new123',
+          url: 'https://lu.ma/product-launch',
+        };
+
+        server.use(
+          http.post('https://public-api.luma.com/v1/event/create', () => {
+            return HttpResponse.json(mockCreatedEvent);
+          })
+        );
+
+        server.listen();
+
+        const tool = LumaConnectorConfig.tools.CREATE_EVENT as MCPToolDefinition;
+        const mockContext = createMockConnectorContext({
+          credentials: {
+            apiKey: 'test-api-key',
+          },
+        });
+
+        const actual = await tool.handler(newEvent, mockContext);
+
+        expect(actual).toContain('"api_id": "evt-new123"');
+        expect(actual).toContain('"name": "Product Launch"');
+        expect(actual).toContain('"capacity": 100');
+
+        server.close();
+      });
+    });
+
+    describe('when creation fails due to validation', () => {
+      it('returns error message', async () => {
+        server.use(
+          http.post('https://public-api.luma.com/v1/event/create', () => {
+            return HttpResponse.json(
+              { error: 'Invalid calendar ID' },
+              { status: 400 }
+            );
+          })
+        );
+
+        server.listen();
+
+        const tool = LumaConnectorConfig.tools.CREATE_EVENT as MCPToolDefinition;
+        const mockContext = createMockConnectorContext({
+          credentials: {
+            apiKey: 'test-api-key',
+          },
+        });
+
+        const actual = await tool.handler(
+          {
+            name: 'Test Event',
+            start_at: '2024-07-20T18:00:00Z',
+            calendar_api_id: 'invalid-cal',
+          },
+          mockContext
+        );
+
+        expect(actual).toContain('Failed to create event');
+        expect(actual).toContain('400');
+
+        server.close();
+      });
+    });
+  });
+
+  describe('.UPDATE_EVENT', () => {
+    describe('when update is successful', () => {
+      it('returns updated event information', async () => {
+        const mockUpdatedEvent = {
+          api_id: 'evt-xyz789',
+          name: 'Updated Conference Name',
+          description: 'Updated description',
+          start_at: '2024-06-16T09:00:00Z',
+          capacity: 600,
+        };
+
+        server.use(
+          http.post('https://public-api.luma.com/v1/event/update', () => {
+            return HttpResponse.json(mockUpdatedEvent);
+          })
+        );
+
+        server.listen();
+
+        const tool = LumaConnectorConfig.tools.UPDATE_EVENT as MCPToolDefinition;
+        const mockContext = createMockConnectorContext({
+          credentials: {
+            apiKey: 'test-api-key',
+          },
+        });
+
+        const actual = await tool.handler(
+          {
+            eventId: 'evt-xyz789',
+            name: 'Updated Conference Name',
+            description: 'Updated description',
+            capacity: 600,
+          },
+          mockContext
+        );
+
+        expect(actual).toContain('"api_id": "evt-xyz789"');
+        expect(actual).toContain('"name": "Updated Conference Name"');
+        expect(actual).toContain('"capacity": 600');
+
+        server.close();
+      });
+    });
+
+    describe('when event does not exist', () => {
+      it('returns error message', async () => {
+        server.use(
+          http.post('https://public-api.luma.com/v1/event/update', () => {
+            return HttpResponse.json({ error: 'Event not found' }, { status: 404 });
+          })
+        );
+
+        server.listen();
+
+        const tool = LumaConnectorConfig.tools.UPDATE_EVENT as MCPToolDefinition;
+        const mockContext = createMockConnectorContext({
+          credentials: {
+            apiKey: 'test-api-key',
+          },
+        });
+
+        const actual = await tool.handler(
+          { eventId: 'nonexistent', name: 'New Name' },
+          mockContext
+        );
+
+        expect(actual).toContain('Failed to update event');
+        expect(actual).toContain('404');
+
+        server.close();
+      });
+    });
+  });
+
+  describe('.GET_GUESTS', () => {
+    describe('when request is successful', () => {
+      it('returns list of guests', async () => {
+        const mockGuests = {
+          entries: [
+            {
+              api_id: 'gst-123',
+              name: 'Alice Smith',
+              email: 'alice@example.com',
+              avatar_url: 'https://example.com/alice.jpg',
+              approval_status: 'approved',
+              registration_status: 'registered',
+              registered_at: '2024-05-01T10:00:00Z',
+            },
+            {
+              api_id: 'gst-456',
+              name: 'Bob Johnson',
+              email: 'bob@example.com',
+              approval_status: 'approved',
+              registration_status: 'registered',
+              registered_at: '2024-05-02T14:30:00Z',
+            },
+          ],
+        };
+
+        server.use(
+          http.get('https://public-api.luma.com/v1/event/get-guests', () => {
+            return HttpResponse.json(mockGuests);
+          })
+        );
+
+        server.listen();
+
+        const tool = LumaConnectorConfig.tools.GET_GUESTS as MCPToolDefinition;
+        const mockContext = createMockConnectorContext({
+          credentials: {
+            apiKey: 'test-api-key',
+          },
+        });
+
+        const actual = await tool.handler({ eventId: 'evt-xyz789' }, mockContext);
+
+        expect(actual).toContain('"api_id": "gst-123"');
+        expect(actual).toContain('"name": "Alice Smith"');
+        expect(actual).toContain('"email": "alice@example.com"');
+
+        server.close();
+      });
+    });
+
+    describe('when filtering by approval status', () => {
+      it('returns filtered guests', async () => {
+        const mockGuests = {
+          entries: [
+            {
+              api_id: 'gst-789',
+              name: 'Charlie Brown',
+              email: 'charlie@example.com',
+              approval_status: 'pending',
+              registration_status: 'registered',
+            },
+          ],
+        };
+
+        server.use(
+          http.get('https://public-api.luma.com/v1/event/get-guests', () => {
+            return HttpResponse.json(mockGuests);
+          })
+        );
+
+        server.listen();
+
+        const tool = LumaConnectorConfig.tools.GET_GUESTS as MCPToolDefinition;
+        const mockContext = createMockConnectorContext({
+          credentials: {
+            apiKey: 'test-api-key',
+          },
+        });
+
+        const actual = await tool.handler(
+          { eventId: 'evt-xyz789', approval_status: 'pending' },
+          mockContext
+        );
+
+        expect(actual).toContain('"approval_status": "pending"');
+        expect(actual).toContain('"name": "Charlie Brown"');
+
+        server.close();
+      });
+    });
+
+    describe('when API returns error', () => {
+      it('returns error message', async () => {
+        server.use(
+          http.get('https://public-api.luma.com/v1/event/get-guests', () => {
+            return HttpResponse.json({ error: 'Event not found' }, { status: 404 });
+          })
+        );
+
+        server.listen();
+
+        const tool = LumaConnectorConfig.tools.GET_GUESTS as MCPToolDefinition;
+        const mockContext = createMockConnectorContext({
+          credentials: {
+            apiKey: 'test-api-key',
+          },
+        });
+
+        const actual = await tool.handler({ eventId: 'nonexistent' }, mockContext);
+
+        expect(actual).toContain('Failed to get guests');
+        expect(actual).toContain('404');
+
+        server.close();
+      });
+    });
+  });
+
+  describe('.GET_GUEST', () => {
+    describe('when guest exists', () => {
+      it('returns detailed guest information', async () => {
+        const mockGuest = {
+          api_id: 'gst-123',
+          name: 'Alice Smith',
+          email: 'alice@example.com',
+          avatar_url: 'https://example.com/alice.jpg',
+          approval_status: 'approved',
+          registration_status: 'registered',
+          registered_at: '2024-05-01T10:00:00Z',
+        };
+
+        server.use(
+          http.get('https://public-api.luma.com/v1/event/get-guest', () => {
+            return HttpResponse.json(mockGuest);
+          })
+        );
+
+        server.listen();
+
+        const tool = LumaConnectorConfig.tools.GET_GUEST as MCPToolDefinition;
+        const mockContext = createMockConnectorContext({
+          credentials: {
+            apiKey: 'test-api-key',
+          },
+        });
+
+        const actual = await tool.handler(
+          { eventId: 'evt-xyz789', guestId: 'gst-123' },
+          mockContext
+        );
+
+        expect(actual).toContain('"api_id": "gst-123"');
+        expect(actual).toContain('"name": "Alice Smith"');
+        expect(actual).toContain('"email": "alice@example.com"');
+
+        server.close();
+      });
+    });
+
+    describe('when guest does not exist', () => {
+      it('returns error message', async () => {
+        server.use(
+          http.get('https://public-api.luma.com/v1/event/get-guest', () => {
+            return HttpResponse.json({ error: 'Guest not found' }, { status: 404 });
+          })
+        );
+
+        server.listen();
+
+        const tool = LumaConnectorConfig.tools.GET_GUEST as MCPToolDefinition;
+        const mockContext = createMockConnectorContext({
+          credentials: {
+            apiKey: 'test-api-key',
+          },
+        });
+
+        const actual = await tool.handler(
+          { eventId: 'evt-xyz789', guestId: 'nonexistent' },
+          mockContext
+        );
+
+        expect(actual).toContain('Failed to get guest');
+        expect(actual).toContain('404');
+
+        server.close();
+      });
+    });
+  });
+
+  describe('.ADD_GUESTS', () => {
+    describe('when adding guests successfully', () => {
+      it('returns added guests information', async () => {
+        const newGuests = [
+          {
+            name: 'David Lee',
+            email: 'david@example.com',
+            approval_status: 'approved',
+          },
+          {
+            name: 'Emma Wilson',
+            email: 'emma@example.com',
+            approval_status: 'approved',
+          },
+        ];
+
+        const mockResponse = {
+          added_guests: [
+            {
+              api_id: 'gst-new1',
+              name: 'David Lee',
+              email: 'david@example.com',
+              approval_status: 'approved',
+              registration_status: 'registered',
+            },
+            {
+              api_id: 'gst-new2',
+              name: 'Emma Wilson',
+              email: 'emma@example.com',
+              approval_status: 'approved',
+              registration_status: 'registered',
+            },
+          ],
+        };
+
+        server.use(
+          http.post('https://public-api.luma.com/v1/event/add-guests', () => {
+            return HttpResponse.json(mockResponse);
+          })
+        );
+
+        server.listen();
+
+        const tool = LumaConnectorConfig.tools.ADD_GUESTS as MCPToolDefinition;
+        const mockContext = createMockConnectorContext({
+          credentials: {
+            apiKey: 'test-api-key',
+          },
+        });
+
+        const actual = await tool.handler(
+          { eventId: 'evt-xyz789', guests: newGuests },
+          mockContext
+        );
+
+        expect(actual).toContain('"api_id": "gst-new1"');
+        expect(actual).toContain('"name": "David Lee"');
+        expect(actual).toContain('"email": "david@example.com"');
+        expect(actual).toContain('"name": "Emma Wilson"');
+
+        server.close();
+      });
+    });
+
+    describe('when adding guests with only email', () => {
+      it('successfully adds guests with minimal information', async () => {
+        const newGuests = [
+          {
+            email: 'frank@example.com',
+          },
+        ];
+
+        const mockResponse = {
+          added_guests: [
+            {
+              api_id: 'gst-new3',
+              email: 'frank@example.com',
+              approval_status: 'pending',
+              registration_status: 'registered',
+            },
+          ],
+        };
+
+        server.use(
+          http.post('https://public-api.luma.com/v1/event/add-guests', () => {
+            return HttpResponse.json(mockResponse);
+          })
+        );
+
+        server.listen();
+
+        const tool = LumaConnectorConfig.tools.ADD_GUESTS as MCPToolDefinition;
+        const mockContext = createMockConnectorContext({
+          credentials: {
+            apiKey: 'test-api-key',
+          },
+        });
+
+        const actual = await tool.handler(
+          { eventId: 'evt-xyz789', guests: newGuests },
+          mockContext
+        );
+
+        expect(actual).toContain('"email": "frank@example.com"');
+        expect(actual).toContain('"api_id": "gst-new3"');
+
+        server.close();
+      });
+    });
+
+    describe('when event is at capacity', () => {
+      it('returns error message', async () => {
+        server.use(
+          http.post('https://public-api.luma.com/v1/event/add-guests', () => {
+            return HttpResponse.json(
+              { error: 'Event is at capacity' },
+              { status: 400 }
+            );
+          })
+        );
+
+        server.listen();
+
+        const tool = LumaConnectorConfig.tools.ADD_GUESTS as MCPToolDefinition;
+        const mockContext = createMockConnectorContext({
+          credentials: {
+            apiKey: 'test-api-key',
+          },
+        });
+
+        const actual = await tool.handler(
+          { eventId: 'evt-xyz789', guests: [{ email: 'test@example.com' }] },
+          mockContext
+        );
+
+        expect(actual).toContain('Failed to add guests');
+        expect(actual).toContain('400');
+
+        server.close();
+      });
+    });
+  });
+
+  describe('.LIST_CALENDAR_EVENTS', () => {
+    describe('when request is successful', () => {
+      it('returns list of calendar events', async () => {
+        const mockEvents = {
+          entries: [
+            {
+              api_id: 'evt-111',
+              name: 'Weekly Standup',
+              start_at: '2024-06-10T10:00:00Z',
+              end_at: '2024-06-10T10:30:00Z',
+              url: 'https://lu.ma/standup',
+              visibility: 'private',
+            },
+            {
+              api_id: 'evt-222',
+              name: 'Team Offsite',
+              start_at: '2024-06-15T09:00:00Z',
+              url: 'https://lu.ma/offsite',
+              cover_url: 'https://example.com/offsite-cover.jpg',
+              visibility: 'public',
+            },
+          ],
+          has_more: false,
+        };
+
+        server.use(
+          http.get('https://public-api.luma.com/v1/calendar/list-events', () => {
+            return HttpResponse.json(mockEvents);
+          })
+        );
+
+        server.listen();
+
+        const tool = LumaConnectorConfig.tools
+          .LIST_CALENDAR_EVENTS as MCPToolDefinition;
+        const mockContext = createMockConnectorContext({
+          credentials: {
+            apiKey: 'test-api-key',
+          },
+        });
+
+        const actual = await tool.handler({ calendarId: 'cal-123' }, mockContext);
+
+        expect(actual).toContain('"api_id": "evt-111"');
+        expect(actual).toContain('"name": "Weekly Standup"');
+        expect(actual).toContain('"name": "Team Offsite"');
+        expect(actual).toContain('"has_more": false');
+
+        server.close();
+      });
+    });
+
+    describe('when filtering by date range', () => {
+      it('returns events within specified dates', async () => {
+        const mockEvents = {
+          entries: [
+            {
+              api_id: 'evt-333',
+              name: 'Summer Event',
+              start_at: '2024-07-01T14:00:00Z',
+              url: 'https://lu.ma/summer',
+              visibility: 'public',
+            },
+          ],
+          has_more: false,
+        };
+
+        server.use(
+          http.get('https://public-api.luma.com/v1/calendar/list-events', () => {
+            return HttpResponse.json(mockEvents);
+          })
+        );
+
+        server.listen();
+
+        const tool = LumaConnectorConfig.tools
+          .LIST_CALENDAR_EVENTS as MCPToolDefinition;
+        const mockContext = createMockConnectorContext({
+          credentials: {
+            apiKey: 'test-api-key',
+          },
+        });
+
+        const actual = await tool.handler(
+          {
+            calendarId: 'cal-123',
+            start_date: '2024-07-01T00:00:00Z',
+            end_date: '2024-07-31T23:59:59Z',
+          },
+          mockContext
+        );
+
+        expect(actual).toContain('"name": "Summer Event"');
+        expect(actual).toContain('"start_at": "2024-07-01T14:00:00Z"');
+
+        server.close();
+      });
+    });
+
+    describe('when pagination is needed', () => {
+      it('returns paginated results with cursor', async () => {
+        const mockEvents = {
+          entries: [
+            {
+              api_id: 'evt-444',
+              name: 'Event 1',
+              start_at: '2024-06-01T10:00:00Z',
+              url: 'https://lu.ma/event1',
+              visibility: 'public',
+            },
+          ],
+          has_more: true,
+          next_cursor: 'cursor-abc123',
+        };
+
+        server.use(
+          http.get('https://public-api.luma.com/v1/calendar/list-events', () => {
+            return HttpResponse.json(mockEvents);
+          })
+        );
+
+        server.listen();
+
+        const tool = LumaConnectorConfig.tools
+          .LIST_CALENDAR_EVENTS as MCPToolDefinition;
+        const mockContext = createMockConnectorContext({
+          credentials: {
+            apiKey: 'test-api-key',
+          },
+        });
+
+        const actual = await tool.handler(
+          { calendarId: 'cal-123', pagination_limit: 1 },
+          mockContext
+        );
+
+        expect(actual).toContain('"has_more": true');
+        expect(actual).toContain('"next_cursor": "cursor-abc123"');
+
+        server.close();
+      });
+    });
+
+    describe('when calendar does not exist', () => {
+      it('returns error message', async () => {
+        server.use(
+          http.get('https://public-api.luma.com/v1/calendar/list-events', () => {
+            return HttpResponse.json({ error: 'Calendar not found' }, { status: 404 });
+          })
+        );
+
+        server.listen();
+
+        const tool = LumaConnectorConfig.tools
+          .LIST_CALENDAR_EVENTS as MCPToolDefinition;
+        const mockContext = createMockConnectorContext({
+          credentials: {
+            apiKey: 'test-api-key',
+          },
+        });
+
+        const actual = await tool.handler({ calendarId: 'nonexistent' }, mockContext);
+
+        expect(actual).toContain('Failed to list calendar events');
+        expect(actual).toContain('404');
+
+        server.close();
+      });
+    });
+  });
+});

--- a/packages/mcp-connectors/src/connectors/luma.ts
+++ b/packages/mcp-connectors/src/connectors/luma.ts
@@ -1,0 +1,478 @@
+import { mcpConnectorConfig } from '@stackone/mcp-config-types';
+import { z } from 'zod';
+
+interface LumaEvent {
+  api_id: string;
+  name: string;
+  description?: string;
+  start_at: string;
+  end_at?: string;
+  timezone?: string;
+  url: string;
+  cover_url?: string;
+  location?: {
+    type: string;
+    address?: string;
+    latitude?: number;
+    longitude?: number;
+  };
+  visibility?: string;
+  capacity?: number;
+  registration_type?: string;
+  [key: string]: unknown;
+}
+
+interface LumaGuest {
+  api_id: string;
+  name: string;
+  email?: string;
+  avatar_url?: string;
+  approval_status: string;
+  registration_status?: string;
+  registered_at?: string;
+  [key: string]: unknown;
+}
+
+interface LumaUser {
+  api_id: string;
+  name: string;
+  username?: string;
+  email?: string;
+  avatar_url?: string;
+  [key: string]: unknown;
+}
+
+interface LumaCalendarEvent {
+  api_id: string;
+  name: string;
+  start_at: string;
+  end_at?: string;
+  url: string;
+  cover_url?: string;
+  visibility?: string;
+  [key: string]: unknown;
+}
+
+class LumaClient {
+  private headers: { 'x-luma-api-key': string; 'Content-Type': string };
+  private baseUrl = 'https://public-api.luma.com/v1';
+
+  constructor(apiKey: string) {
+    this.headers = {
+      'x-luma-api-key': apiKey,
+      'Content-Type': 'application/json',
+    };
+  }
+
+  private async makeRequest(
+    endpoint: string,
+    method: 'GET' | 'POST' | 'PUT' | 'DELETE' = 'GET',
+    body?: unknown
+  ): Promise<unknown> {
+    const url = `${this.baseUrl}/${endpoint}`;
+    const options: RequestInit = {
+      method,
+      headers: this.headers,
+    };
+
+    if (body && (method === 'POST' || method === 'PUT')) {
+      options.body = JSON.stringify(body);
+    }
+
+    const response = await fetch(url, options);
+
+    if (!response.ok) {
+      const errorText = await response.text();
+      throw new Error(
+        `Luma API error: ${response.status} ${response.statusText} - ${errorText}`
+      );
+    }
+
+    return response.json();
+  }
+
+  // User Management
+  async getSelf(): Promise<LumaUser> {
+    return (await this.makeRequest('user/get-self')) as LumaUser;
+  }
+
+  // Event Management
+  async getEvent(eventId: string): Promise<LumaEvent> {
+    const params = new URLSearchParams({ event_api_id: eventId });
+    return (await this.makeRequest(`event/get?${params.toString()}`)) as LumaEvent;
+  }
+
+  async createEvent(eventData: {
+    name: string;
+    start_at: string;
+    calendar_api_id: string;
+    description?: string;
+    end_at?: string;
+    timezone?: string;
+    location?: {
+      type: string;
+      address?: string;
+    };
+    visibility?: string;
+    capacity?: number;
+  }): Promise<LumaEvent> {
+    return (await this.makeRequest('event/create', 'POST', eventData)) as LumaEvent;
+  }
+
+  async updateEvent(
+    eventId: string,
+    updateData: {
+      name?: string;
+      description?: string;
+      start_at?: string;
+      end_at?: string;
+      timezone?: string;
+      location?: {
+        type: string;
+        address?: string;
+      };
+      visibility?: string;
+      capacity?: number;
+    }
+  ): Promise<LumaEvent> {
+    return (await this.makeRequest('event/update', 'POST', {
+      event_api_id: eventId,
+      ...updateData,
+    })) as LumaEvent;
+  }
+
+  // Guest Management
+  async getGuests(
+    eventId: string,
+    filters?: {
+      approval_status?: string;
+      registration_status?: string;
+    }
+  ): Promise<{ entries: LumaGuest[] }> {
+    const params = new URLSearchParams({ event_api_id: eventId });
+    if (filters?.approval_status) {
+      params.set('approval_status', filters.approval_status);
+    }
+    if (filters?.registration_status) {
+      params.set('registration_status', filters.registration_status);
+    }
+    return (await this.makeRequest(`event/get-guests?${params.toString()}`)) as {
+      entries: LumaGuest[];
+    };
+  }
+
+  async getGuest(eventId: string, guestId: string): Promise<LumaGuest> {
+    const params = new URLSearchParams({
+      event_api_id: eventId,
+      guest_api_id: guestId,
+    });
+    return (await this.makeRequest(`event/get-guest?${params.toString()}`)) as LumaGuest;
+  }
+
+  async addGuests(
+    eventId: string,
+    guests: Array<{
+      name?: string;
+      email?: string;
+      approval_status?: string;
+    }>
+  ): Promise<{ added_guests: LumaGuest[] }> {
+    return (await this.makeRequest('event/add-guests', 'POST', {
+      event_api_id: eventId,
+      guests,
+    })) as { added_guests: LumaGuest[] };
+  }
+
+  // Calendar Management
+  async listCalendarEvents(
+    calendarId: string,
+    filters?: {
+      start_date?: string;
+      end_date?: string;
+      pagination_limit?: number;
+      pagination_cursor?: string;
+    }
+  ): Promise<{ entries: LumaCalendarEvent[]; has_more: boolean; next_cursor?: string }> {
+    const params = new URLSearchParams({ calendar_api_id: calendarId });
+    if (filters?.start_date) {
+      params.set('period_start', filters.start_date);
+    }
+    if (filters?.end_date) {
+      params.set('period_end', filters.end_date);
+    }
+    if (filters?.pagination_limit) {
+      params.set('pagination_limit', filters.pagination_limit.toString());
+    }
+    if (filters?.pagination_cursor) {
+      params.set('pagination_cursor', filters.pagination_cursor);
+    }
+    return (await this.makeRequest(`calendar/list-events?${params.toString()}`)) as {
+      entries: LumaCalendarEvent[];
+      has_more: boolean;
+      next_cursor?: string;
+    };
+  }
+}
+
+export const LumaConnectorConfig = mcpConnectorConfig({
+  name: 'Lu.ma',
+  key: 'luma',
+  version: '1.0.0',
+  logo: 'https://cdn.brandfetch.io/idM0FJHHLh/theme/dark/logo.svg?c=1dxbfHSJFAPEGdCLU4o5B',
+  credentials: z.object({
+    apiKey: z
+      .string()
+      .describe(
+        'Luma API Key from Settings > API (requires Luma Plus subscription) :: https://docs.luma.com/reference/getting-started-with-your-api'
+      ),
+  }),
+  setup: z.object({}),
+  examplePrompt:
+    'Get information about my Luma account, list upcoming events in my calendar, create a new event, and retrieve guest information.',
+  tools: (tool) => ({
+    GET_SELF: tool({
+      name: 'luma_get_self',
+      description: 'Get information about the authenticated Luma user',
+      schema: z.object({}),
+      handler: async (_, context) => {
+        try {
+          const { apiKey } = await context.getCredentials();
+          const client = new LumaClient(apiKey);
+          const result = await client.getSelf();
+          return JSON.stringify(result, null, 2);
+        } catch (error) {
+          return `Failed to get user info: ${error instanceof Error ? error.message : String(error)}`;
+        }
+      },
+    }),
+
+    GET_EVENT: tool({
+      name: 'luma_get_event',
+      description: 'Get detailed information about a specific event',
+      schema: z.object({
+        eventId: z.string().describe('Event API ID'),
+      }),
+      handler: async (args, context) => {
+        try {
+          const { apiKey } = await context.getCredentials();
+          const client = new LumaClient(apiKey);
+          const result = await client.getEvent(args.eventId);
+          return JSON.stringify(result, null, 2);
+        } catch (error) {
+          return `Failed to get event: ${error instanceof Error ? error.message : String(error)}`;
+        }
+      },
+    }),
+
+    CREATE_EVENT: tool({
+      name: 'luma_create_event',
+      description: 'Create a new event in Luma',
+      schema: z.object({
+        name: z.string().describe('Event name'),
+        start_at: z
+          .string()
+          .describe('Event start time in ISO 8601 format (e.g., 2024-03-20T19:00:00Z)'),
+        calendar_api_id: z
+          .string()
+          .describe('Calendar API ID where event will be created'),
+        description: z.string().optional().describe('Event description'),
+        end_at: z
+          .string()
+          .optional()
+          .describe('Event end time in ISO 8601 format (e.g., 2024-03-20T21:00:00Z)'),
+        timezone: z.string().optional().describe('Timezone (e.g., America/New_York)'),
+        location: z
+          .object({
+            type: z
+              .string()
+              .describe(
+                'Location type (e.g., venue, online, tbd, address, google_meet, zoom)'
+              ),
+            address: z.string().optional().describe('Physical address or meeting URL'),
+          })
+          .optional()
+          .describe('Event location details'),
+        visibility: z
+          .string()
+          .optional()
+          .describe('Event visibility (e.g., public, private, unlisted)'),
+        capacity: z.number().optional().describe('Maximum number of attendees'),
+      }),
+      handler: async (args, context) => {
+        try {
+          const { apiKey } = await context.getCredentials();
+          const client = new LumaClient(apiKey);
+          const result = await client.createEvent(args);
+          return JSON.stringify(result, null, 2);
+        } catch (error) {
+          return `Failed to create event: ${error instanceof Error ? error.message : String(error)}`;
+        }
+      },
+    }),
+
+    UPDATE_EVENT: tool({
+      name: 'luma_update_event',
+      description: 'Update an existing event in Luma',
+      schema: z.object({
+        eventId: z.string().describe('Event API ID'),
+        name: z.string().optional().describe('Event name'),
+        description: z.string().optional().describe('Event description'),
+        start_at: z
+          .string()
+          .optional()
+          .describe('Event start time in ISO 8601 format (e.g., 2024-03-20T19:00:00Z)'),
+        end_at: z
+          .string()
+          .optional()
+          .describe('Event end time in ISO 8601 format (e.g., 2024-03-20T21:00:00Z)'),
+        timezone: z.string().optional().describe('Timezone (e.g., America/New_York)'),
+        location: z
+          .object({
+            type: z
+              .string()
+              .describe(
+                'Location type (e.g., venue, online, tbd, address, google_meet, zoom)'
+              ),
+            address: z.string().optional().describe('Physical address or meeting URL'),
+          })
+          .optional()
+          .describe('Event location details'),
+        visibility: z
+          .string()
+          .optional()
+          .describe('Event visibility (e.g., public, private, unlisted)'),
+        capacity: z.number().optional().describe('Maximum number of attendees'),
+      }),
+      handler: async (args, context) => {
+        try {
+          const { apiKey } = await context.getCredentials();
+          const client = new LumaClient(apiKey);
+          const { eventId, ...updateData } = args;
+          const result = await client.updateEvent(eventId, updateData);
+          return JSON.stringify(result, null, 2);
+        } catch (error) {
+          return `Failed to update event: ${error instanceof Error ? error.message : String(error)}`;
+        }
+      },
+    }),
+
+    GET_GUESTS: tool({
+      name: 'luma_get_guests',
+      description: 'Get guests for a specific event',
+      schema: z.object({
+        eventId: z.string().describe('Event API ID'),
+        approval_status: z
+          .string()
+          .optional()
+          .describe('Filter by approval status (e.g., approved, pending, rejected)'),
+        registration_status: z
+          .string()
+          .optional()
+          .describe(
+            'Filter by registration status (e.g., registered, waitlisted, cancelled)'
+          ),
+      }),
+      handler: async (args, context) => {
+        try {
+          const { apiKey } = await context.getCredentials();
+          const client = new LumaClient(apiKey);
+          const result = await client.getGuests(args.eventId, {
+            approval_status: args.approval_status,
+            registration_status: args.registration_status,
+          });
+          return JSON.stringify(result, null, 2);
+        } catch (error) {
+          return `Failed to get guests: ${error instanceof Error ? error.message : String(error)}`;
+        }
+      },
+    }),
+
+    GET_GUEST: tool({
+      name: 'luma_get_guest',
+      description: 'Get detailed information about a specific guest',
+      schema: z.object({
+        eventId: z.string().describe('Event API ID'),
+        guestId: z.string().describe('Guest API ID'),
+      }),
+      handler: async (args, context) => {
+        try {
+          const { apiKey } = await context.getCredentials();
+          const client = new LumaClient(apiKey);
+          const result = await client.getGuest(args.eventId, args.guestId);
+          return JSON.stringify(result, null, 2);
+        } catch (error) {
+          return `Failed to get guest: ${error instanceof Error ? error.message : String(error)}`;
+        }
+      },
+    }),
+
+    ADD_GUESTS: tool({
+      name: 'luma_add_guests',
+      description: 'Add guests to an event',
+      schema: z.object({
+        eventId: z.string().describe('Event API ID'),
+        guests: z
+          .array(
+            z.object({
+              name: z.string().optional().describe('Guest name'),
+              email: z.string().email().optional().describe('Guest email address'),
+              approval_status: z
+                .string()
+                .optional()
+                .describe('Approval status (e.g., approved, pending)'),
+            })
+          )
+          .describe('Array of guests to add'),
+      }),
+      handler: async (args, context) => {
+        try {
+          const { apiKey } = await context.getCredentials();
+          const client = new LumaClient(apiKey);
+          const result = await client.addGuests(args.eventId, args.guests);
+          return JSON.stringify(result, null, 2);
+        } catch (error) {
+          return `Failed to add guests: ${error instanceof Error ? error.message : String(error)}`;
+        }
+      },
+    }),
+
+    LIST_CALENDAR_EVENTS: tool({
+      name: 'luma_list_calendar_events',
+      description: 'List events from a specific calendar',
+      schema: z.object({
+        calendarId: z.string().describe('Calendar API ID'),
+        start_date: z
+          .string()
+          .optional()
+          .describe('Filter events starting from this date (ISO 8601)'),
+        end_date: z
+          .string()
+          .optional()
+          .describe('Filter events ending before this date (ISO 8601)'),
+        pagination_limit: z
+          .number()
+          .optional()
+          .describe('Maximum number of events to return (default: 50)'),
+        pagination_cursor: z
+          .string()
+          .optional()
+          .describe('Cursor for pagination to get next page of results'),
+      }),
+      handler: async (args, context) => {
+        try {
+          const { apiKey } = await context.getCredentials();
+          const client = new LumaClient(apiKey);
+          const result = await client.listCalendarEvents(args.calendarId, {
+            start_date: args.start_date,
+            end_date: args.end_date,
+            pagination_limit: args.pagination_limit,
+            pagination_cursor: args.pagination_cursor,
+          });
+          return JSON.stringify(result, null, 2);
+        } catch (error) {
+          return `Failed to list calendar events: ${error instanceof Error ? error.message : String(error)}`;
+        }
+      },
+    }),
+  }),
+});

--- a/packages/mcp-connectors/src/connectors/luma.ts
+++ b/packages/mcp-connectors/src/connectors/luma.ts
@@ -218,7 +218,7 @@ export const LumaConnectorConfig = mcpConnectorConfig({
   name: 'Lu.ma',
   key: 'luma',
   version: '1.0.0',
-  logo: 'https://cdn.brandfetch.io/idM0FJHHLh/theme/dark/logo.svg?c=1dxbfHSJFAPEGdCLU4o5B',
+  logo: 'https://stackone-logos.com/api/luma/filled/svg',
   credentials: z.object({
     apiKey: z
       .string()

--- a/packages/mcp-connectors/src/index.ts
+++ b/packages/mcp-connectors/src/index.ts
@@ -18,6 +18,7 @@ import { GitLabConnectorConfig } from './connectors/gitlab';
 import { GoogleDriveConnectorConfig } from './connectors/google-drive';
 import { googleMapsConnector as GoogleMapsConnectorConfig } from './connectors/google-maps';
 import { GraphyConnectorConfig } from './connectors/graphy';
+import { HarnessConnectorConfig } from './connectors/harness';
 import { HiBobConnectorConfig } from './connectors/hibob';
 import { HubSpotConnectorConfig } from './connectors/hubspot';
 import { IncidentConnectorConfig } from './connectors/incident';
@@ -71,6 +72,7 @@ export const Connectors: readonly MCPConnectorConfig[] = [
   GoogleDriveConnectorConfig,
   GoogleMapsConnectorConfig,
   GraphyConnectorConfig,
+  HarnessConnectorConfig,
   HiBobConnectorConfig,
   HubSpotConnectorConfig,
   IncidentConnectorConfig,
@@ -124,6 +126,7 @@ export {
   GoogleDriveConnectorConfig,
   GoogleMapsConnectorConfig,
   GraphyConnectorConfig,
+  HarnessConnectorConfig,
   HiBobConnectorConfig,
   HubSpotConnectorConfig,
   IncidentConnectorConfig,

--- a/packages/mcp-connectors/src/index.ts
+++ b/packages/mcp-connectors/src/index.ts
@@ -26,6 +26,7 @@ import { JiraConnectorConfig } from './connectors/jira';
 import { LangsmithConnectorConfig } from './connectors/langsmith';
 import { LinearConnectorConfig } from './connectors/linear';
 import { LinkedInConnectorConfig } from './connectors/linkedin';
+import { LumaConnectorConfig } from './connectors/luma';
 import { ModalConnectorConfig } from './connectors/modal';
 import { NotionConnectorConfig } from './connectors/notion';
 import { OnePasswordConnectorConfig } from './connectors/onepassword';
@@ -82,6 +83,7 @@ export const Connectors: readonly MCPConnectorConfig[] = [
   LinearConnectorConfig,
   LinkedInConnectorConfig,
   LogfireConnectorConfig,
+  LumaConnectorConfig,
   ModalConnectorConfig,
   NotionConnectorConfig,
   OnePasswordConnectorConfig,
@@ -136,6 +138,7 @@ export {
   LinearConnectorConfig,
   LinkedInConnectorConfig,
   LogfireConnectorConfig,
+  LumaConnectorConfig,
   ModalConnectorConfig,
   NotionConnectorConfig,
   OnePasswordConnectorConfig,


### PR DESCRIPTION

    
<!-- This is an auto-generated description by cubic. -->

## Summary by cubic
Adds Luma and Harness MCP connectors, enabling Luma event/calendar management and Harness feature flag operations. Both connectors are registered in the index and covered by tests.

- **New Features**
  - Luma connector: GET_SELF, GET_EVENT, CREATE_EVENT, UPDATE_EVENT, GET_GUESTS, GET_GUEST, ADD_GUESTS, LIST_CALENDAR_EVENTS (with credential schema, example prompt, and error handling).
  - Harness connector: GET_FEATURE_FLAGS, GET_FEATURE_FLAG, CREATE_FEATURE_FLAG, UPDATE_FEATURE_FLAG, TOGGLE_FEATURE_FLAG, DELETE_FEATURE_FLAG, GET_TARGETS, GET_TARGET_GROUPS, GET_FEATURE_FLAG_METRICS (with credential schema, example prompt, and error handling).
  - Index updated to include both connectors; comprehensive MSW/Vitest tests for happy/error paths.

<!-- End of auto-generated description by cubic. -->

