### PR TITLE
fix: remove mcp-config-types package from GitHub workflows and documentation

### DIFF
--- a/.release-please-config.json
+++ b/.release-please-config.json
@@ -5,11 +5,6 @@
             "bump-minor-pre-major": true,
             "bump-patch-for-minor-pre-major": true
         },
-        "packages/mcp-config-types": {
-            "release-type": "node",
-            "bump-minor-pre-major": true,
-            "bump-patch-for-minor-pre-major": true
-        },
         "apps/mcp-test": {
             "release-type": "node",
             "bump-minor-pre-major": true,

--- a/.release-please-manifest.json
+++ b/.release-please-manifest.json
@@ -1,5 +1,4 @@
 {
     "packages/mcp-connectors": "0.0.21",
-    "packages/mcp-config-types": "0.0.12",
     "apps/mcp-test": "0.0.7"
 }

--- a/README.md
+++ b/README.md
@@ -1,9 +1,8 @@
 <div align="center">
   <img src="./docs/assets/logo.png" alt="Disco Logo" width="400" />
 
-  [![License](https://img.shields.io/badge/License-Apache_2.0-blue.svg)](https://opensource.org/licenses/Apache-2.0)
-  [![npm version](https://badge.fury.io/js/@stackone%2Fmcp-connectors.svg)](https://badge.fury.io/js/@stackone%2Fmcp-connectors)
-  [![npm version](https://badge.fury.io/js/@stackone%2Fmcp-config-types.svg)](https://badge.fury.io/js/@stackone%2Fmcp-config-types)
+[![License](https://img.shields.io/badge/License-Apache_2.0-blue.svg)](https://opensource.org/licenses/Apache-2.0)
+[![npm version](https://badge.fury.io/js/@stackone%2Fmcp-connectors.svg)](https://badge.fury.io/js/@stackone%2Fmcp-connectors)
 
 > Pre-built MCP connectors for popular SaaS tools - powers [disco.dev](https://disco.dev)
 
@@ -21,10 +20,6 @@ This monorepo contains two packages built with TypeScript and Zod:
 - No dependencies on server runtime or transport
 - Runs on Bun, Node, and Cloudflare Workers
 
-**@stackone/mcp-config-types** - Shared configuration types
-
-- Zod schemas for connector credentials and setup fields
-- TypeScript types for all connector configurations
 - Designed for AI coding agents (Claude, Cursor, etc.)
 - Enables type-safe connector development
 
@@ -41,10 +36,10 @@ Go to [disco.dev](https://disco.dev) to get started with zero setup.
 Use these packages to build your own MCP servers:
 
 ```bash
-npm install @stackone/mcp-connectors @stackone/mcp-config-types
+npm install @stackone/mcp-connectors
 ```
 
-The connectors can be imported and used in your own MCP server implementations, and the config types provide TypeScript definitions for all connector configurations.
+The connectors can be imported and used in your own MCP server implementations.
 
 ## Getting Started (First Time Setup)
 
@@ -81,7 +76,7 @@ If you want to run the connectors locally or contribute to the project:
    bun test
    ```
 
-5. **Check out the documentation:**
+6. **Check out the documentation:**
    - See the [`docs/`](./docs/) directory for detailed guides
    - Start with [Running Locally](./docs/running-locally.md) for setup instructions
    - Read [Writing Connectors](./docs/writing-connectors.md) to create your own
@@ -108,7 +103,6 @@ Server runs at `http://localhost:3000/mcp`
 ### Package structure
 
 - `packages/mcp-connectors/` - The main connectors package
-- `packages/mcp-config-types/` - Shared configuration types
 
 ## Available Connectors
 

--- a/docs/writing-connectors.md
+++ b/docs/writing-connectors.md
@@ -57,7 +57,7 @@ Tests must follow this exact structure pattern:
 
 ```typescript
 import { describe, expect, it } from "vitest";
-import type { MCPToolDefinition } from "@stackone/mcp-config-types";
+import type { MCPToolDefinition } from "@modelcontextprotocol/sdk/types.js";
 import { createMockConnectorContext } from "../__mocks__/context";
 import { YourConnectorConfig } from "./your-connector";
 

--- a/packages/mcp-connectors/README.md
+++ b/packages/mcp-connectors/README.md
@@ -12,23 +12,26 @@ Production-ready TypeScript connectors for 45+ SaaS tools including GitHub, Slac
 ## Installation
 
 ```bash
-npm install @stackone/mcp-connectors @stackone/mcp-config-types
+npm install @stackone/mcp-connectors
 ```
 
 ## Usage
 
 ```typescript
-import { GitHubConnectorConfig } from '@stackone/mcp-connectors';
+import { GitHubConnectorConfig } from "@stackone/mcp-connectors";
 
 // Get a tool from a connector
 const createIssueTool = GitHubConnectorConfig.tools.CREATE_ISSUE;
 
 // Use in your MCP server
-const result = await createIssueTool.handler({
-  owner: 'stackone-ai',
-  repo: 'mcp-connectors',
-  title: 'New feature request'
-}, context);
+const result = await createIssueTool.handler(
+  {
+    owner: "stackone-ai",
+    repo: "mcp-connectors",
+    title: "New feature request",
+  },
+  context
+);
 ```
 
 ## Available Connectors (45+)


### PR DESCRIPTION
- Remove mcp-config-types from .release-please-config.json
- Remove mcp-config-types from .release-please-manifest.json
- Update README.md to remove references to mcp-config-types package
- Update packages/mcp-connectors/README.md installation instructions
- Update docs/writing-connectors.md to use @modelcontextprotocol/sdk/types.js
- Fix code formatting in README examples

This ensures the GitHub workflows will only release the remaining packages
after the mcp-config-types package was removed in the previous PR.
    
<!-- This is an auto-generated description by cubic. -->
---

## Summary by cubic
Removed the deprecated mcp-config-types from release workflows and docs so only supported packages are published. Updated type references to @modelcontextprotocol/sdk/types.js and cleaned up examples.

- **Refactors**
  - Removed mcp-config-types entries from .release-please-config.json and .release-please-manifest.json.
  - Updated README files to drop mcp-config-types from install instructions and usage.
  - Switched MCPToolDefinition import to @modelcontextprotocol/sdk/types.js.
  - Fixed code formatting in README examples.

<!-- End of auto-generated description by cubic. -->

